### PR TITLE
Update theme colors and header

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -192,7 +192,7 @@
   </style>
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -208,11 +208,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="KF Megaglass Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">KF Megaglass</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>

--- a/glass-doors.html
+++ b/glass-doors.html
@@ -18,7 +18,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/icons/android-chrome-512x512.png" />
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -34,11 +34,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="KF Megaglass Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">KF Megaglass</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>

--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@
   <meta property="og:title" content="PK Paints n' Renovations - Painting &amp; Carpentry" />
   <meta property="og:description"
     content="Serving the tri-state area with quality painting and remodeling solutions." />
-  <meta property="og:image" content="assets/brand-logo.png" />
+  <meta property="og:image" content="assets/icons/logo.png" />
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://www.pkpaints.com/" />
   <meta property="twitter:title" content="PK Paints n' Renovations" />
   <meta property="twitter:description"
     content="Your trusted partner for painting and carpentry." />
-  <meta property="twitter:image" content="assets/brand-logo.png" />
+  <meta property="twitter:image" content="assets/icons/logo.png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="icon" href="assets/icons/favicon.ico" type="image/x-icon" />
@@ -36,7 +36,7 @@
         "@context": "https://schema.org",
         "@type": "ProfessionalService",
         "name": "PK Paints n' Renovations",
-        "image": "assets/brand-logo.png",
+        "image": "assets/icons/logo.png",
         "@id": "https://www.pkpaints.com/",
         "url": "https://www.pkpaints.com/",
         "telephone": "+1-215-603-8009",
@@ -91,7 +91,7 @@
   </style>
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -109,11 +109,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">PK Paints n' Renovations</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>
@@ -217,7 +213,7 @@
       <!-- Contact Info Section for Mobile -->
       <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
         <a href="tel:2672435478"
-          class="flex items-center text-sm text-orange-400 hover:text-orange-300 transition-colors duration-200">
+          class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
           <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -226,7 +222,7 @@
           (215) 603-8009
         </a>
         <a href="mailto:peterkpaint@gmail.com"
-          class="flex items-center text-sm text-orange-400 hover:text-orange-300 transition-colors duration-200">
+          class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
           <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -310,7 +306,7 @@
               covered.
             </p>
             <a href="#contact"
-              class="bg-gradient-to-r from-orange-500 to-orange-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
+              class="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
               Get Free Quote
             </a>
           </div>
@@ -376,7 +372,7 @@
         <div class="md:hidden space-y-4 mb-8">
           <a href="shower-enclosures.html" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
-              class="w-12 h-12 bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg flex items-center justify-center mr-4">
+              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"></path>
@@ -393,7 +389,7 @@
 
           <a href="glass-doors.html" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
-              class="w-12 h-12 bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg flex items-center justify-center mr-4">
+              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M8.25 9V7a3.75 3.75 0 117.5 0v2m-7.5 4v6.75A1.25 1.25 0 009.5 21h5a1.25 1.25 0 001.25-1.25V13M8.25 9h7.5a1.25 1.25 0 011.25 1.25V13">
@@ -411,7 +407,7 @@
 
           <a href="#" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
-              class="w-12 h-12 bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg flex items-center justify-center mr-4">
+              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z">
@@ -429,7 +425,7 @@
 
           <a href="#" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
-              class="w-12 h-12 bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg flex items-center justify-center mr-4">
+              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M3 4h18M3 8h18M3 12h18M3 16h18M3 20h18"></path>
@@ -451,14 +447,14 @@
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
-                class="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
+                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                 <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"></path>
                 </svg>
               </div>
               <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-orange-300 transition-colors duration-300">
+                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
                 Interior Painting
               </h3>
               <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
@@ -471,7 +467,7 @@
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
-                class="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
+                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                 <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M8.25 9V7a3.75 3.75 0 117.5 0v2m-7.5 4v6.75A1.25 1.25 0 009.5 21h5a1.25 1.25 0 001.25-1.25V13M8.25 9h7.5a1.25 1.25 0 011.25 1.25V13">
@@ -479,7 +475,7 @@
                 </svg>
               </div>
               <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-orange-300 transition-colors duration-300">
+                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
                 Exterior Painting
               </h3>
               <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
@@ -492,7 +488,7 @@
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
-                class="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
+                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                 <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z">
@@ -500,7 +496,7 @@
                 </svg>
               </div>
               <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-orange-300 transition-colors duration-300">
+                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
                 Carpentry
               </h3>
               <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
@@ -513,14 +509,14 @@
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
-                class="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
+                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                 <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M3 4h18M3 8h18M3 12h18M3 16h18M3 20h18"></path>
                 </svg>
               </div>
               <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-orange-300 transition-colors duration-300">
+                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
                 Remodeling
               </h3>
               <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
@@ -585,7 +581,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
               <div class="text-center">
                 <div class="glass-card w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg class="w-8 h-8 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-8 h-8 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
                     </path>
@@ -594,14 +590,14 @@
                 <h3 class="text-lg font-semibold text-white mb-2">
                 </h3>
                 <a href="tel:2672435478"
-                  class="text-orange-400 hover:text-orange-300 text-xl font-medium transition-colors duration-200">
+                  class="text-yellow-400 hover:text-yellow-300 text-xl font-medium transition-colors duration-200">
                   (267) 243-5478
                 </a>
               </div>
 
               <div class="text-center">
                 <div class="glass-card w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg class="w-8 h-8 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="w-8 h-8 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
                     </path>
@@ -610,7 +606,7 @@
                 <h3 class="text-lg font-semibold text-white mb-2">
                 </h3>
                 <a href="tel:2672524314"
-                  class="text-orange-400 hover:text-orange-300 text-xl font-medium transition-colors duration-200">
+                  class="text-yellow-400 hover:text-yellow-300 text-xl font-medium transition-colors duration-200">
                   (267) 252-4314
                 </a>
               </div>
@@ -618,14 +614,14 @@
 
             <div class="text-center border-t border-gray-700/50 pt-8">
               <div class="glass-card w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg class="w-8 h-8 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-8 h-8 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
                   </path>
                 </svg>
               </div>
               <a href="mailto:peterkpaint@gmail.com"
-                class="text-orange-400 hover:text-orange-300 text-xl font-medium transition-colors duration-200">
+                class="text-yellow-400 hover:text-yellow-300 text-xl font-medium transition-colors duration-200">
                 peterkpaint@gmail.com
               </a>
             </div>
@@ -650,7 +646,7 @@
         class="glass-card inline-flex items-center justify-center w-12 h-12 rounded-full hover-glass transition-colors
         duration-300"
         aria-label="PK Paints on Facebook">
-        <svg class="w-6 h-6 text-orange-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <svg class="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path fill-rule="evenodd"
             d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
             clip-rule="evenodd" />

--- a/partitions.html
+++ b/partitions.html
@@ -18,7 +18,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/icons/android-chrome-512x512.png" />
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -34,11 +34,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="KF Megaglass Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">KF Megaglass</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>

--- a/railings.html
+++ b/railings.html
@@ -18,7 +18,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/icons/android-chrome-512x512.png" />
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -34,11 +34,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="KF Megaglass Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">KF Megaglass</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>

--- a/shower-enclosures.html
+++ b/shower-enclosures.html
@@ -18,7 +18,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="assets/icons/android-chrome-512x512.png" />
 </head>
 
-<body class="bg-slate-900 text-gray-200 antialiased font-inter">
+<body class="bg-gray-950 text-gray-200 antialiased font-inter">
   <!-- Background shapes -->
   <div class="bg-shapes fixed inset-0 pointer-events-none">
     <div class="bg-shape bg-shape-1"></div>
@@ -34,11 +34,7 @@
           <div class="flex-shrink-0">
             <a href="index.html" class="text-2xl font-bold text-white">
               <div class="glass-card-nav rounded-lg px-4 py-2">
-                <img src="assets/brand-logo.png" alt="KF Megaglass Logo" class="h-12 rounded-md"
-                  onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='flex';" />
-                <div class="h-12 w-48 rounded-md items-center justify-center hidden">
-                  <span class="gradient-text font-bold text-xl">KF Megaglass</span>
-                </div>
+                <img src="assets/icons/logo.png" alt="PK Paints n' Renovations Logo" class="h-12 rounded-md" />
               </div>
             </a>
           </div>

--- a/src/style.css
+++ b/src/style.css
@@ -185,7 +185,7 @@ body {
   text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
     -1px -1px 0px rgba(57, 132, 185, 0.9), 1px -1px 0px rgba(33, 12, 137, 0.9),
     -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
-    0 0 20px rgba(249, 115, 22, 0.6) !important;
+    0 0 20px rgba(212, 175, 55, 0.6) !important;
 }
 .glass-card-hero p .gradient-text {
   /* Add custom text-shadow properties here if desired */
@@ -193,7 +193,7 @@ body {
   text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.195),
     -1px -1px 0px rgba(57, 132, 185, 0.7), 1px -1px 0px rgba(33, 12, 137, 0.7),
     -1px 1px 0px rgba(0, 0, 0, 0.7), 2px 2px 4px rgba(0, 0, 0, 0.6),
-    0 0 10px rgba(249, 115, 22, 0.4) !important;
+    0 0 10px rgba(212, 175, 55, 0.4) !important;
 }
 
 /* Make the hero card background more refined */
@@ -257,9 +257,9 @@ body {
 }
 
 .glass-indicator.active {
-  background: rgba(249, 115, 22, 0.9) !important;
+  background: rgba(212, 175, 55, 0.9) !important;
   border-color: white !important;
-  box-shadow: 0 0 15px rgba(249, 115, 22, 0.8);
+  box-shadow: 0 0 15px rgba(212, 175, 55, 0.8);
 }
 
 /* ==================== SERVICE PAGE HERO ==================== */
@@ -337,7 +337,7 @@ body {
   text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
     -1px -1px 0px rgba(57, 132, 185, 0.9), 1px -1px 0px rgba(33, 12, 137, 0.9),
     -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
-    0 0 20px rgba(249, 115, 22, 0.6) !important;
+    0 0 20px rgba(212, 175, 55, 0.6) !important;
 }
 
 /* Mobile optimization */
@@ -399,22 +399,22 @@ body {
 
 .service-card:hover {
   background: rgba(255, 255, 255, 0.1) !important;
-  border-color: rgba(249, 115, 22, 0.3) !important;
+  border-color: rgba(212, 175, 55, 0.3) !important;
   transform: translateY(-8px) scale(1.02);
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4), 0 0 40px rgba(249, 115, 22, 0.2) !important;
+  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4), 0 0 40px rgba(212, 175, 55, 0.2) !important;
 }
 
 /* Make service icons more premium */
 .service-card .bg-gradient-to-br {
-  background: linear-gradient(135deg, #f97316, #c2410c) !important;
-  box-shadow: 0 8px 25px rgba(249, 115, 22, 0.3),
+  background: linear-gradient(135deg, #d4af37, #b8860b) !important;
+  box-shadow: 0 8px 25px rgba(212, 175, 55, 0.3),
     inset 0 1px 0 rgba(255, 255, 255, 0.2) !important;
   transition: all 0.3s ease;
 }
 
 .service-card:hover .bg-gradient-to-br {
   transform: scale(1.1) rotate(5deg);
-  box-shadow: 0 12px 35px rgba(249, 115, 22, 0.4),
+  box-shadow: 0 12px 35px rgba(212, 175, 55, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.3) !important;
 }
 
@@ -451,9 +451,9 @@ body {
 }
 
 .gallery-item:hover {
-  border-color: rgba(249, 115, 22, 0.3);
+  border-color: rgba(212, 175, 55, 0.3);
   transform: scale(1.03) rotate(0.5deg);
-  box-shadow: 0 25px 70px rgba(249, 115, 22, 0.2);
+  box-shadow: 0 25px 70px rgba(212, 175, 55, 0.2);
 }
 
 /* On hover, make the overlay visible */
@@ -481,13 +481,13 @@ body {
 /* Contact icons - glass treatment */
 .contact-card .glass-card {
   background: rgba(255, 255, 255, 0.06) !important;
-  border: 1px solid rgba(249, 115, 22, 0.2) !important;
+  border: 1px solid rgba(212, 175, 55, 0.2) !important;
   transition: all 0.3s ease;
 }
 
 .contact-card .glass-card:hover {
-  background: rgba(249, 115, 22, 0.1) !important;
-  border-color: rgba(249, 115, 22, 0.4) !important;
+  background: rgba(212, 175, 55, 0.1) !important;
+  border-color: rgba(212, 175, 55, 0.4) !important;
   transform: scale(1.05);
 }
 
@@ -505,7 +505,7 @@ footer {
 
 /* Gradient text effect */
 .gradient-text {
-  background: linear-gradient(135deg, #f97316, #c2410c);
+  background: linear-gradient(135deg, #d4af37, #b8860b);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -541,7 +541,7 @@ button {
 /* Focus states for accessibility */
 a:focus,
 button:focus {
-  outline: 2px solid #f97316;
+  outline: 2px solid #d4af37;
   outline-offset: 2px;
 }
 
@@ -560,23 +560,23 @@ button:focus {
 
 /* Enhanced shadow system */
 .shadow-glow {
-  box-shadow: 0 0 20px rgba(249, 115, 22, 0.3);
+  box-shadow: 0 0 20px rgba(212, 175, 55, 0.3);
 }
 
 .shadow-glow-hover:hover {
-  box-shadow: 0 0 30px rgba(249, 115, 22, 0.4);
+  box-shadow: 0 0 30px rgba(212, 175, 55, 0.4);
 }
 
 /* Improve button visibility */
 .btn-primary {
-  background: linear-gradient(135deg, #f97316, #c2410c) !important;
-  box-shadow: 0 4px 15px rgba(249, 115, 22, 0.4);
+  background: linear-gradient(135deg, #d4af37, #b8860b) !important;
+  box-shadow: 0 4px 15px rgba(212, 175, 55, 0.4);
   text-shadow: none; /* Buttons don't need text shadow */
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .btn-primary:hover {
-  box-shadow: 0 6px 20px rgba(249, 115, 22, 0.6);
+  box-shadow: 0 6px 20px rgba(212, 175, 55, 0.6);
   transform: translateY(-2px);
 }
 
@@ -603,8 +603,8 @@ button:focus {
   height: 200px;
   background: linear-gradient(
     45deg,
-    rgba(249, 115, 22, 0.03),
-    rgba(194, 65, 12, 0.03)
+    rgba(212, 175, 55, 0.03),
+    rgba(184, 134, 11, 0.03)
   );
   border-radius: 50%;
   filter: blur(60px);
@@ -617,8 +617,8 @@ button:focus {
   left: 10%;
   background: linear-gradient(
     45deg,
-    rgba(251, 146, 60, 0.03),
-    rgba(249, 115, 22, 0.03)
+    rgba(230, 200, 120, 0.03),
+    rgba(212, 175, 55, 0.03)
   );
 }
 

--- a/template_service.html
+++ b/template_service.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="src/style.css" />
   </head>
-  <body class="bg-slate-900 text-gray-200 antialiased font-inter">
+  <body class="bg-gray-950 text-gray-200 antialiased font-inter">
     {{HEADER}}
     <main class="pt-32 pb-16">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- modernize header with logo only
- change site background to darker gray
- switch accent colors from orange to gold
- update service pages with new logo and colors

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cf881e28832b8eaaa2e29c9a27e6