### PR TITLE
Ensure gallery grid is visible without observer

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -374,7 +374,7 @@
     <!-- Gallery Grid -->
     <section class="pb-20 md:pb-32 relative">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="gallery-grid fade-in"></div>
+        <div class="gallery-grid fade-in visible"></div>
       </div>
     </section>
   </main>

--- a/src/gallery-builder.js
+++ b/src/gallery-builder.js
@@ -40,7 +40,7 @@ export async function buildGallery() {
   let markup = '';
   for (const imageUrl of images) {
     markup += `
-      <div class="gallery-item glass-card rounded-xl overflow-hidden">
+      <div class="gallery-item glass-card rounded-xl overflow-hidden fade-in">
         <img src="${imageUrl}" loading="lazy" alt="gallery image" onerror="this.parentElement.style.display='none'" />
       </div>
     `;

--- a/src/script.js
+++ b/src/script.js
@@ -572,6 +572,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const markup = await buildGallery();
     if (grid) {
       grid.innerHTML = markup;
+      grid.classList.add('visible');
     }
 
     // 2. then wire up your enhancements


### PR DESCRIPTION
## Summary
- Make gallery grid visible by default and after dynamic markup insertion
- Apply `fade-in` class to individual gallery items for per-image animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad30a76878832baaac4c29d4bb716d