### PR TITLE
Convert glass service pages to painting and renovation offerings

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Glass Railings | PK Paints n' Renovations</title>
+  <title>Carpentry | PK Paints n' Renovations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -52,29 +52,29 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
-                Products
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
+                Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="shower-enclosures.html"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Showers</a>
-                <a href="glass-doors.html"
+                  role="menuitem">Interior Painting</a>
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Doors</a>
-                <a href="partitions.html"
+                  role="menuitem">Exterior Painting</a>
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Partitions</a>
-                <a href="railings.html"
+                  role="menuitem">Carpentry</a>
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Railings</a>
+                  role="menuitem">Remodeling</a>
               </div>
             </div>
 
@@ -144,24 +144,24 @@
         <a href="index.html"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
         <div class="relative">
-          <button id="mobile-products-button"
+          <button id="mobile-services-button"
             class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-            aria-expanded="false" aria-controls="mobile-products-menu">
-            Products
+            aria-expanded="false" aria-controls="mobile-services-menu">
+            Services
             <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
               viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-            <a href="shower-enclosures.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Showers</a>
-            <a href="glass-doors.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Doors</a>
-            <a href="partitions.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Partitions</a>
-            <a href="railings.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Railings</a>
+          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+            <a href="interior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior Painting</a>
+            <a href="exterior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior Painting</a>
+            <a href="carpentry.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+            <a href="remodeling.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
         <a href="gallery.html"
@@ -174,17 +174,16 @@
 
   <main class="relative z-10">
     <!-- Service Hero Section -->
-    <section class="service-hero railings-hero text-white">
+    <section class="service-hero carpentry-hero text-white">
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Stunning <span class="gradient-text">Glass Railings</span>
+              Custom <span class="gradient-text">Carpentry</span>
             </h1>
             <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Combine safety with elegance using custom
-              <span class="gradient-text">glass railing systems</span> that preserve
-              stunning views while ensuring complete protection.
+              Enhance your home with quality woodwork, trim, and repairs
+              crafted to fit your style and needs.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
@@ -208,12 +207,12 @@
           <div>
             <div class="glass-card stack-layer rounded-2xl p-8">
               <h2 class="text-4xl lg:text-5xl font-bold text-white mb-8">
-                Why Choose Our <span class="gradient-text">Glass Railings</span>?
+                Why Choose Our <span class="gradient-text">Carpentry Services</span>?
               </h2>
               <div class="space-y-6 text-gray-300 text-lg leading-relaxed">
                 <p>
-                  Our glass railings deliver uncompromising safety without sacrificing the breathtaking views that make
-                  your space special. Perfect for modern architecture and outdoor living.
+                  From custom builds to detailed repairs, our carpenters bring
+                  craftsmanship and care to every project.
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
@@ -221,28 +220,21 @@
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Unobstructed panoramic views from any level</span>
+                    <span>Trim and molding installation</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Weather-resistant and low maintenance design</span>
+                    <span>Built-in shelving and storage solutions</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Meets all safety codes and building requirements</span>
-                  </li>
-                  <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
-                      viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                    </svg>
-                    <span>Ideal for decks, balconies, stairs, and pool areas</span>
+                    <span>Repair and restoration of damaged woodwork</span>
                   </li>
                 </ul>
               </div>
@@ -250,9 +242,9 @@
           </div>
           <div>
             <div class="gallery-item float-2">
-              <img src="assets/gallery/railing_02.jpg" alt="Custom Glass Railing Installation"
+              <img src="assets/stain_door.png" alt="Custom carpentry project"
                 class="rounded-2xl shadow-2xl w-full h-auto object-cover"
-                onerror="this.src='https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80';" />
+                onerror="this.src='https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1000&q=80';" />
             </div>
           </div>
         </div>
@@ -277,7 +269,7 @@
       </div>
       <p class="text-gray-400 text-sm mb-2">
         &copy; 2013 - <span id="currentYear"></span> PK Paints n' Renovations -
-        Frameless Glass Solutions. All Rights Reserved.
+        Painting & Renovation Solutions. All Rights Reserved.
       </p>
       <p class="text-gray-500 text-xs">Website by PK Designs</p>
     </div>

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Shower Enclosures | PK Paints n' Renovations</title>
+  <title>Exterior Painting | PK Paints n' Renovations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -52,29 +52,29 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
-                Products
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
+                Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="shower-enclosures.html"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Showers</a>
-                <a href="glass-doors.html"
+                  role="menuitem">Interior Painting</a>
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Doors</a>
-                <a href="partitions.html"
+                  role="menuitem">Exterior Painting</a>
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Partitions</a>
-                <a href="railings.html"
+                  role="menuitem">Carpentry</a>
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Railings</a>
+                  role="menuitem">Remodeling</a>
               </div>
             </div>
 
@@ -144,27 +144,24 @@
         <a href="index.html"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
         <div class="relative">
-          <button id="mobile-products-button"
+          <button id="mobile-services-button"
             class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-            aria-expanded="false" aria-controls="mobile-products-menu">
-            Products
+            aria-expanded="false" aria-controls="mobile-services-menu">
+            Services
             <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
               viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-            <a href="shower-enclosures.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Shower
-              Enclosures</a>
-            <a href="glass-doors.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Glass
-              Doors</a>
-            <a href="partitions.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Partition
-              Systems</a>
-            <a href="railings.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Railings</a>
+          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+            <a href="interior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior Painting</a>
+            <a href="exterior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior Painting</a>
+            <a href="carpentry.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+            <a href="remodeling.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
         <a href="gallery.html"
@@ -177,17 +174,16 @@
 
   <main class="relative z-10">
     <!-- Service Hero Section -->
-    <section class="service-hero shower-hero text-white">
+    <section class="service-hero exterior-hero text-white">
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Premium <span class="gradient-text">Shower Enclosures</span>
+              Expert <span class="gradient-text">Exterior Painting</span>
             </h1>
             <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Transform your bathroom with custom
-              <span class="gradient-text">frameless glass</span> shower
-              enclosures designed for elegance and functionality.
+              Protect and beautify your home with long-lasting finishes
+              designed to withstand the elements.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
@@ -211,12 +207,12 @@
           <div>
             <div class="glass-card stack-layer rounded-2xl p-8">
               <h2 class="text-4xl lg:text-5xl font-bold text-white mb-8">
-                Why Choose Our <span class="gradient-text">Shower Enclosures</span>?
+                Why Choose Our <span class="gradient-text">Exterior Painting</span>?
               </h2>
               <div class="space-y-6 text-gray-300 text-lg leading-relaxed">
                 <p>
-                  Our frameless shower enclosures combine sophisticated design with practical functionality, creating a
-                  spa-like experience in your own home.
+                  From prep to final coat, we ensure your home's exterior
+                  stays protected and looks fantastic for years.
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
@@ -224,28 +220,21 @@
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Premium tempered glass for safety and durability</span>
+                    <span>Thorough surface prep and power washing</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Custom measurements to fit any bathroom layout</span>
+                    <span>Weather-resistant coatings for lasting protection</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>High-quality hardware with lifetime warranty</span>
-                  </li>
-                  <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
-                      viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                    </svg>
-                    <span>Professional installation by certified technicians</span>
+                    <span>Boosts curb appeal and home value</span>
                   </li>
                 </ul>
               </div>
@@ -253,9 +242,9 @@
           </div>
           <div>
             <div class="gallery-item float-2">
-              <img src="/assets/gallery/showers_09.jpg" alt="Premium Shower Enclosure"
+              <img src="assets/exterior.png" alt="Exterior painting project"
                 class="rounded-2xl shadow-2xl w-full h-auto object-cover"
-                onerror="this.src='https://images.unsplash.com/photo-1584622650111-993a426fbf0a?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80';" />
+                onerror="this.src='https://images.unsplash.com/photo-1493415301200-33f9da7e6500?auto=format&fit=crop&w=1000&q=80';" />
             </div>
           </div>
         </div>
@@ -280,7 +269,7 @@
       </div>
       <p class="text-gray-400 text-sm mb-2">
         &copy; 2013 - <span id="currentYear"></span> PK Paints n' Renovations -
-        Frameless Glass Solutions. All Rights Reserved.
+        Painting & Renovation Solutions. All Rights Reserved.
       </p>
       <p class="text-gray-500 text-xs">Website by PK Designs</p>
     </div>

--- a/gallery.html
+++ b/gallery.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gallery | PK Paints n' Renovations - Frameless Glass Solutions</title>
   <meta name="description"
-    content="Explore our portfolio of custom frameless glass installations including shower enclosures, glass doors, partitions, and railings." />
+    content="Explore our portfolio of interior and exterior painting, carpentry, and remodeling projects." />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -231,29 +231,29 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
-                Products
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
+                Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="shower-enclosures.html"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Showers</a>
-                <a href="glass-doors.html"
+                  role="menuitem">Interior Painting</a>
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Doors</a>
-                <a href="partitions.html"
+                  role="menuitem">Exterior Painting</a>
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Partitions</a>
-                <a href="railings.html"
+                  role="menuitem">Carpentry</a>
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Railings</a>
+                  role="menuitem">Remodeling</a>
               </div>
             </div>
 
@@ -323,24 +323,24 @@
         <a href="index.html"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
         <div class="relative">
-          <button id="mobile-products-button"
+          <button id="mobile-services-button"
             class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-            aria-expanded="false" aria-controls="mobile-products-menu">
-            Products
+            aria-expanded="false" aria-controls="mobile-services-menu">
+            Services
             <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
               viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-            <a href="shower-enclosures.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Showers</a>
-            <a href="glass-doors.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Doors</a>
-            <a href="partitions.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Partitions</a>
-            <a href="railings.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Railings</a>
+          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+            <a href="interior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior Painting</a>
+            <a href="exterior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior Painting</a>
+            <a href="carpentry.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+            <a href="remodeling.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
         <a href="gallery.html"

--- a/index.html
+++ b/index.html
@@ -143,27 +143,27 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
                 Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="#"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Interior Painting</a>
-                <a href="#"
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Exterior Painting</a>
-                <a href="#"
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Carpentry</a>
-                <a href="#"
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
               </div>
@@ -236,27 +236,27 @@
       <a href="#"
         class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
       <div class="relative">
-        <button id="mobile-products-button"
+        <button id="mobile-services-button"
           class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-          aria-expanded="false" aria-controls="mobile-products-menu">
-          Products
+          aria-expanded="false" aria-controls="mobile-services-menu">
+          Services
           <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
             viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
-        <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-          <a href="#"
+        <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <a href="interior-painting.html"
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
             Painting</a>
-          <a href="#"
+          <a href="exterior-painting.html"
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior
             Painting</a>
-          <a href="#"
+          <a href="carpentry.html"
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
-          <a href="#"
+          <a href="remodeling.html"
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
-        </div> <!-- This closes the div.relative for mobile products dropdown -->
+        </div> <!-- This closes the div.relative for mobile services dropdown -->
       </div>
       <a href="gallery.html"
         class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
@@ -371,7 +371,7 @@
 
         <!-- Mobile: Simple Links -->
         <div class="md:hidden space-y-4 mb-8">
-          <a href="shower-enclosures.html" class="mobile-service-link flex items-center p-4 rounded-xl">
+          <a href="interior-painting.html" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
               class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -388,7 +388,7 @@
             </svg>
           </a>
 
-          <a href="glass-doors.html" class="mobile-service-link flex items-center p-4 rounded-xl">
+          <a href="exterior-painting.html" class="mobile-service-link flex items-center p-4 rounded-xl">
             <div
               class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
               <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -444,7 +444,7 @@
 
         <!-- Desktop: Compact horizontal row -->
         <div class="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-4 xl:gap-6">
-          <a href="shower-enclosures.html" class="desktop-service-link group">
+          <a href="interior-painting.html" class="desktop-service-link group">
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
@@ -464,7 +464,7 @@
             </div>
           </a>
 
-          <a href="glass-doors.html" class="desktop-service-link group">
+          <a href="exterior-painting.html" class="desktop-service-link group">
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
@@ -485,7 +485,7 @@
             </div>
           </a>
 
-          <a href="partitions.html" class="desktop-service-link group">
+          <a href="carpentry.html" class="desktop-service-link group">
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div
@@ -506,7 +506,7 @@
             </div>
           </a>
 
-          <a href="railings.html" class="desktop-service-link group">
+          <a href="remodeling.html" class="desktop-service-link group">
             <div
               class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow">
               <div

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Partitions | PK Paints n' Renovations</title>
+  <title>Interior Painting | PK Paints n' Renovations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -52,29 +52,29 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
-                Products
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
+                Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="shower-enclosures.html"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Showers</a>
-                <a href="glass-doors.html"
+                  role="menuitem">Interior Painting</a>
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Doors</a>
-                <a href="partitions.html"
+                  role="menuitem">Exterior Painting</a>
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Partitions</a>
-                <a href="railings.html"
+                  role="menuitem">Carpentry</a>
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Railings</a>
+                  role="menuitem">Remodeling</a>
               </div>
             </div>
 
@@ -144,24 +144,24 @@
         <a href="index.html"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
         <div class="relative">
-          <button id="mobile-products-button"
+          <button id="mobile-services-button"
             class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-            aria-expanded="false" aria-controls="mobile-products-menu">
-            Products
+            aria-expanded="false" aria-controls="mobile-services-menu">
+            Services
             <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
               viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-            <a href="shower-enclosures.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Showers</a>
-            <a href="glass-doors.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Doors</a>
-            <a href="partitions.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Partitions</a>
-            <a href="railings.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Railings</a>
+          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+            <a href="interior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior Painting</a>
+            <a href="exterior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior Painting</a>
+            <a href="carpentry.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+            <a href="remodeling.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
         <a href="gallery.html"
@@ -174,17 +174,16 @@
 
   <main class="relative z-10">
     <!-- Service Hero Section -->
-    <section class="service-hero partitions-hero text-white">
+    <section class="service-hero interior-hero text-white">
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Professional <span class="gradient-text">Glass Partitions</span>
+              Professional <span class="gradient-text">Interior Painting</span>
             </h1>
             <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Define spaces beautifully with custom
-              <span class="gradient-text">glass partition systems</span> that maintain
-              openness while creating functional divisions.
+              Refresh your living spaces with crisp lines and vibrant colors
+              delivered by our experienced painting team.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
@@ -208,12 +207,12 @@
           <div>
             <div class="glass-card stack-layer rounded-2xl p-8">
               <h2 class="text-4xl lg:text-5xl font-bold text-white mb-8">
-                Why Choose Our <span class="gradient-text">Partition Systems</span>?
+                Why Choose Our <span class="gradient-text">Interior Painting</span>?
               </h2>
               <div class="space-y-6 text-gray-300 text-lg leading-relaxed">
                 <p>
-                  Our glass partition systems revolutionize workspace design by creating defined areas while preserving
-                  the open, collaborative atmosphere that modern businesses demand.
+                  We take pride in delivering smooth, long-lasting finishes that make
+                  your home feel brand new.
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
@@ -221,28 +220,21 @@
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Maintains visual connectivity while defining spaces</span>
+                    <span>Careful prep work for clean, sharp results</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Flexible configurations for changing needs</span>
+                    <span>Premium paints for vibrant, durable color</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Sound dampening without visual barriers</span>
-                  </li>
-                  <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
-                      viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                    </svg>
-                    <span>Perfect for offices, restaurants, and retail spaces</span>
+                    <span>Respectful cleanup leaving your space spotless</span>
                   </li>
                 </ul>
               </div>
@@ -250,9 +242,9 @@
           </div>
           <div>
             <div class="gallery-item float-2">
-              <img src="/assets/gallery/partition_03.jpg" alt="Glass Partition System Installation"
+              <img src="assets/dine.png" alt="Interior painting project"
                 class="rounded-2xl shadow-2xl w-full h-auto object-cover"
-                onerror="this.src='https://images.unsplash.com/photo-1600566753376-12c8ab7fb75b?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80';" />
+                onerror="this.src='https://images.unsplash.com/photo-1507668077129-56a5b31c7a33?auto=format&fit=crop&w=1000&q=80';" />
             </div>
           </div>
         </div>
@@ -277,7 +269,7 @@
       </div>
       <p class="text-gray-400 text-sm mb-2">
         &copy; 2013 - <span id="currentYear"></span> PK Paints n' Renovations -
-        Frameless Glass Solutions. All Rights Reserved.
+        Painting & Renovation Solutions. All Rights Reserved.
       </p>
       <p class="text-gray-500 text-xs">Website by PK Designs</p>
     </div>

--- a/remodeling.html
+++ b/remodeling.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Glass Doors | PK Paints n' Renovations</title>
+  <title>Remodeling | PK Paints n' Renovations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -52,29 +52,29 @@
             <div class="relative dropdown group">
               <button
                 class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium inline-flex items-center transition-all duration-200"
-                aria-haspopup="true" aria-expanded="false" id="desktop-products-button"
-                aria-controls="desktop-products-menu">
-                Products
+                aria-haspopup="true" aria-expanded="false" id="desktop-services-button"
+                aria-controls="desktop-services-menu">
+                Services
                 <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
                   viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </button>
-              <div id="desktop-products-menu"
+              <div id="desktop-services-menu"
                 class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
                 role="menu">
-                <a href="shower-enclosures.html"
+                <a href="interior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Showers</a>
-                <a href="glass-doors.html"
+                  role="menuitem">Interior Painting</a>
+                <a href="exterior-painting.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Doors</a>
-                <a href="partitions.html"
+                  role="menuitem">Exterior Painting</a>
+                <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Partitions</a>
-                <a href="railings.html"
+                  role="menuitem">Carpentry</a>
+                <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Railings</a>
+                  role="menuitem">Remodeling</a>
               </div>
             </div>
 
@@ -144,24 +144,24 @@
         <a href="index.html"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Home</a>
         <div class="relative">
-          <button id="mobile-products-button"
+          <button id="mobile-services-button"
             class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
-            aria-expanded="false" aria-controls="mobile-products-menu">
-            Products
+            aria-expanded="false" aria-controls="mobile-services-menu">
+            Services
             <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
               viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-products-menu" class="hidden pl-4 bg-gray-750/50">
-            <a href="shower-enclosures.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Showers</a>
-            <a href="glass-doors.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Doors</a>
-            <a href="partitions.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Partitions</a>
-            <a href="railings.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Railings</a>
+          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+            <a href="interior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior Painting</a>
+            <a href="exterior-painting.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior Painting</a>
+            <a href="carpentry.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+            <a href="remodeling.html"
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
         <a href="gallery.html"
@@ -174,17 +174,16 @@
 
   <main class="relative z-10">
     <!-- Service Hero Section -->
-    <section class="service-hero doors-hero text-white">
+    <section class="service-hero remodeling-hero text-white">
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Frameless <span class="gradient-text">Glass Doors</span>
+              Comprehensive <span class="gradient-text">Remodeling</span>
             </h1>
             <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Create seamless transitions with custom
-              <span class="gradient-text">frameless glass doors</span> that combine
-              elegance with functionality for any space.
+              Transform your space with expert renovations tailored to your
+              vision and lifestyle.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
@@ -208,12 +207,12 @@
           <div>
             <div class="glass-card stack-layer rounded-2xl p-8">
               <h2 class="text-4xl lg:text-5xl font-bold text-white mb-8">
-                Why Choose Our <span class="gradient-text">Glass Doors</span>?
+                Why Choose Our <span class="gradient-text">Remodeling Services</span>?
               </h2>
               <div class="space-y-6 text-gray-300 text-lg leading-relaxed">
                 <p>
-                  Our frameless glass doors create stunning architectural statements while maximizing natural light flow
-                  and visual continuity throughout your space.
+                  We handle every aspect of your renovation, delivering
+                  beautiful, functional spaces.
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
@@ -221,28 +220,21 @@
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Seamless integration with modern architecture</span>
+                    <span>Kitchen and bathroom upgrades</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Maximizes natural light and open space feeling</span>
+                    <span>Flooring and layout improvements</span>
                   </li>
                   <li class="flex items-start">
                     <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
-                    <span>Precision-engineered hardware for smooth operation</span>
-                  </li>
-                  <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
-                      viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                    </svg>
-                    <span>Suitable for residential and commercial applications</span>
+                    <span>Project management from start to finish</span>
                   </li>
                 </ul>
               </div>
@@ -250,9 +242,9 @@
           </div>
           <div>
             <div class="gallery-item float-2">
-              <img src="/assets/gallery/doors_07.jpg" alt="Modern Glass Door Installation"
+              <img src="assets/bunk_bed.png" alt="Remodeling project"
                 class="rounded-2xl shadow-2xl w-full h-auto object-cover"
-                onerror="this.src='https://images.unsplash.com/photo-1571708655418-b2b1c510a7db?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80';" />
+                onerror="this.src='https://images.unsplash.com/photo-1507089947368-19c1da9775ae?auto=format&fit=crop&w=1000&q=80';" />
             </div>
           </div>
         </div>
@@ -277,7 +269,7 @@
       </div>
       <p class="text-gray-400 text-sm mb-2">
         &copy; 2013 - <span id="currentYear"></span> PK Paints n' Renovations -
-        Frameless Glass Solutions. All Rights Reserved.
+        Painting & Renovation Solutions. All Rights Reserved.
       </p>
       <p class="text-gray-500 text-xs">Website by PK Designs</p>
     </div>

--- a/src/script.js
+++ b/src/script.js
@@ -71,50 +71,50 @@ document.addEventListener('DOMContentLoaded', async () => {
   const mobileMenuButton = document.getElementById('mobile-menu-button');
   const mobileMenu = document.getElementById('mobile-menu');
 
-  // Mobile products dropdown toggle
-  const mobileProductsButton = document.getElementById(
-    'mobile-products-button'
+  // Mobile services dropdown toggle
+  const mobileServicesButton = document.getElementById(
+    'mobile-services-button'
   );
-  const mobileProductsMenu = document.getElementById('mobile-products-menu');
-  const mobileProductsButtonSvg = mobileProductsButton
-    ? mobileProductsButton.querySelector('svg')
+  const mobileServicesMenu = document.getElementById('mobile-services-menu');
+  const mobileServicesButtonSvg = mobileServicesButton
+    ? mobileServicesButton.querySelector('svg')
     : null;
 
-  // Desktop products dropdown toggle (for aria attributes, actual visibility is CSS driven)
-  const desktopProductsButton = document.getElementById(
-    'desktop-products-button'
+  // Desktop services dropdown toggle (for aria attributes, actual visibility is CSS driven)
+  const desktopServicesButton = document.getElementById(
+    'desktop-services-button'
   );
-  const desktopProductsMenu = document.getElementById('desktop-products-menu');
+  const desktopServicesMenu = document.getElementById('desktop-services-menu');
 
   if (mobileMenuButton && mobileMenu) {
     mobileMenuButton.addEventListener('click', () => {
       const isExpanded = mobileMenu.classList.toggle('hidden');
       mobileMenuButton.setAttribute('aria-expanded', !isExpanded); // True if menu is NOT hidden (visible)
 
-      // If mobile menu is closed, also ensure product submenu is closed and its button aria is updated
+      // If mobile menu is closed, also ensure services submenu is closed and its button aria is updated
       if (
         isExpanded &&
-        mobileProductsMenu &&
-        !mobileProductsMenu.classList.contains('hidden')
+        mobileServicesMenu &&
+        !mobileServicesMenu.classList.contains('hidden')
       ) {
-        mobileProductsMenu.classList.add('hidden');
-        if (mobileProductsButton) {
-          mobileProductsButton.setAttribute('aria-expanded', 'false');
-          if (mobileProductsButtonSvg)
-            mobileProductsButtonSvg.style.transform = ''; // Reset arrow
+        mobileServicesMenu.classList.add('hidden');
+        if (mobileServicesButton) {
+          mobileServicesButton.setAttribute('aria-expanded', 'false');
+          if (mobileServicesButtonSvg)
+            mobileServicesButtonSvg.style.transform = ''; // Reset arrow
         }
       }
     });
   }
 
-  if (mobileProductsButton && mobileProductsMenu) {
-    mobileProductsButton.addEventListener('click', (e) => {
+  if (mobileServicesButton && mobileServicesMenu) {
+    mobileServicesButton.addEventListener('click', (e) => {
       e.preventDefault(); // Prevent page jump if it's an anchor
-      const isExpanded = mobileProductsMenu.classList.toggle('hidden');
-      mobileProductsButton.setAttribute('aria-expanded', !isExpanded); // True if menu is NOT hidden
-      if (mobileProductsButtonSvg) {
+      const isExpanded = mobileServicesMenu.classList.toggle('hidden');
+      mobileServicesButton.setAttribute('aria-expanded', !isExpanded); // True if menu is NOT hidden
+      if (mobileServicesButtonSvg) {
         // Rotate arrow icon
-        mobileProductsButtonSvg.style.transform = !isExpanded
+        mobileServicesButtonSvg.style.transform = !isExpanded
           ? 'rotate(180deg)'
           : '';
       }
@@ -122,44 +122,44 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   // Handle ARIA for desktop dropdown (visibility is CSS driven by :hover)
-  if (desktopProductsButton && desktopProductsMenu) {
-    const dropdownParent = desktopProductsButton.closest('.dropdown'); // Get the parent .dropdown element
+  if (desktopServicesButton && desktopServicesMenu) {
+    const dropdownParent = desktopServicesButton.closest('.dropdown'); // Get the parent .dropdown element
 
     if (dropdownParent) {
       dropdownParent.addEventListener('mouseenter', () => {
-        desktopProductsButton.setAttribute('aria-expanded', 'true');
+        desktopServicesButton.setAttribute('aria-expanded', 'true');
       });
 
       dropdownParent.addEventListener('mouseleave', () => {
-        desktopProductsButton.setAttribute('aria-expanded', 'false');
+        desktopServicesButton.setAttribute('aria-expanded', 'false');
       });
 
       // For keyboard accessibility
-      desktopProductsButton.addEventListener('focus', () => {
-        desktopProductsButton.setAttribute('aria-expanded', 'true');
+      desktopServicesButton.addEventListener('focus', () => {
+        desktopServicesButton.setAttribute('aria-expanded', 'true');
       });
 
       // Need to handle focusout carefully to not close when focusing on menu items
       const menuItems =
-        desktopProductsMenu.querySelectorAll('a[role="menuitem"]');
+        desktopServicesMenu.querySelectorAll('a[role="menuitem"]');
       const lastMenuItem = menuItems[menuItems.length - 1];
 
       if (lastMenuItem) {
         lastMenuItem.addEventListener('blur', (event) => {
           // If focus moves outside the dropdown menu, close it
           if (
-            !desktopProductsMenu.contains(event.relatedTarget) &&
-            event.relatedTarget !== desktopProductsButton
+            !desktopServicesMenu.contains(event.relatedTarget) &&
+            event.relatedTarget !== desktopServicesButton
           ) {
-            desktopProductsButton.setAttribute('aria-expanded', 'false');
+            desktopServicesButton.setAttribute('aria-expanded', 'false');
           }
         });
       }
       // Close dropdown if Escape key is pressed
       dropdownParent.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
-          desktopProductsButton.setAttribute('aria-expanded', 'false');
-          desktopProductsButton.focus(); // Return focus to the button
+          desktopServicesButton.setAttribute('aria-expanded', 'false');
+          desktopServicesButton.focus(); // Return focus to the button
         }
       });
     }
@@ -195,14 +195,14 @@ document.addEventListener('DOMContentLoaded', async () => {
               mobileMenuButton.setAttribute('aria-expanded', 'false');
               // Also close product submenu if open
               if (
-                mobileProductsMenu &&
-                !mobileProductsMenu.classList.contains('hidden')
-              ) {
-                mobileProductsMenu.classList.add('hidden');
-                if (mobileProductsButton)
-                  mobileProductsButton.setAttribute('aria-expanded', 'false');
-                if (mobileProductsButtonSvg)
-                  mobileProductsButtonSvg.style.transform = '';
+        mobileServicesMenu &&
+        !mobileServicesMenu.classList.contains('hidden')
+      ) {
+        mobileServicesMenu.classList.add('hidden');
+        if (mobileServicesButton)
+          mobileServicesButton.setAttribute('aria-expanded', 'false');
+        if (mobileServicesButtonSvg)
+          mobileServicesButtonSvg.style.transform = '';
               }
             }
           } else {

--- a/src/style.css
+++ b/src/style.css
@@ -91,7 +91,7 @@ body {
 }
 
 /* Style for the mobile products dropdown arrow rotation */
-#mobile-products-button[aria-expanded='true'] svg {
+#mobile-services-button[aria-expanded='true'] svg {
   transform: rotate(180deg);
 }
 
@@ -278,21 +278,21 @@ body {
   overflow: hidden;
 }
 
-/* Shower enclosures specific background */
-.shower-hero {
-  background-image: url('/assets/gallery/panels.jpg');
+/* Interior painting specific background */
+.interior-hero {
+  background-image: url('/assets/dine.png');
 }
-/* Glass doors specific background */
-.doors-hero {
-  background-image: url('/assets/gallery/panels2.jpg');
+/* Exterior painting specific background */
+.exterior-hero {
+  background-image: url('/assets/exterior.png');
 }
-/* Partitions specific background */
-.partitions-hero {
-  background-image: url('/assets/gallery/partition_04.jpg');
+/* Carpentry specific background */
+.carpentry-hero {
+  background-image: url('/assets/stain_door.png');
 }
-/* Railings specific background */
-.railings-hero {
-  background-image: url('/assets/gallery/railing_14.jpg');
+/* Remodeling specific background */
+.remodeling-hero {
+  background-image: url('/assets/bunk_bed.png');
 }
 
 /* Dark overlay for text readability */
@@ -775,7 +775,7 @@ button:focus {
 }
 
 /* Mobile products submenu - clear glass */
-#mobile-products-menu {
+#mobile-services-menu {
   background: rgba(255, 255, 255, 0.03) !important;
 }
 .mobile-contact-compact {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,10 +12,10 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         gallery: resolve(__dirname, 'gallery.html'),
-        'glass-doors': resolve(__dirname, 'glass-doors.html'),
-        partitions: resolve(__dirname, 'partitions.html'),
-        railings: resolve(__dirname, 'railings.html'),
-        'shower-enclosures': resolve(__dirname, 'shower-enclosures.html'),
+        'exterior-painting': resolve(__dirname, 'exterior-painting.html'),
+        carpentry: resolve(__dirname, 'carpentry.html'),
+        remodeling: resolve(__dirname, 'remodeling.html'),
+        'interior-painting': resolve(__dirname, 'interior-painting.html'),
       },
       output: {
         assetFileNames: 'assets/[name]-[hash].[ext]',


### PR DESCRIPTION
## Summary
- Replace legacy glass service pages with new Interior Painting, Exterior Painting, Carpentry, and Remodeling pages
- Update navigation menus and build config to reference new services
- Introduce service-specific hero images and rename JS/CSS hooks from products to services

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad42b2a1b4832b981cacf1869e11d3