### PR TITLE
Refine hero gradients to match PK Paints branding

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -187,7 +187,7 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
-                class="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
+                class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
                 Get Free Quote
               </a>
               <a href="gallery.html"

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -187,7 +187,7 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
-                class="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
+                class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
                 Get Free Quote
               </a>
               <a href="gallery.html"

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -190,7 +190,7 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
-                class="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
+                class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
                 Get Free Quote
               </a>
               <a href="gallery.html"

--- a/remodeling.html
+++ b/remodeling.html
@@ -187,7 +187,7 @@
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
-                class="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
+                class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">
                 Get Free Quote
               </a>
               <a href="gallery.html"

--- a/src/style.css
+++ b/src/style.css
@@ -183,7 +183,7 @@ body {
 
 .glass-card-hero h1 .gradient-text {
   text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
-    -1px -1px 0px rgba(57, 132, 185, 0.9), 1px -1px 0px rgba(33, 12, 137, 0.9),
+    -1px -1px 0px rgba(200, 161, 72, 0.9), 1px -1px 0px rgba(79, 50, 8, 0.9),
     -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
     0 0 20px rgba(212, 175, 55, 0.6) !important;
 }
@@ -191,7 +191,7 @@ body {
   /* Add custom text-shadow properties here if desired */
   /* For example, to give it a subtle glow similar to the h1, but perhaps less intense: */
   text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.195),
-    -1px -1px 0px rgba(57, 132, 185, 0.7), 1px -1px 0px rgba(33, 12, 137, 0.7),
+    -1px -1px 0px rgba(200, 161, 72, 0.7), 1px -1px 0px rgba(79, 50, 8, 0.7),
     -1px 1px 0px rgba(0, 0, 0, 0.7), 2px 2px 4px rgba(0, 0, 0, 0.6),
     0 0 10px rgba(212, 175, 55, 0.4) !important;
 }
@@ -335,7 +335,7 @@ body {
 
 .service-hero .glass-card-hero h1 .gradient-text {
   text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
-    -1px -1px 0px rgba(57, 132, 185, 0.9), 1px -1px 0px rgba(33, 12, 137, 0.9),
+    -1px -1px 0px rgba(200, 161, 72, 0.9), 1px -1px 0px rgba(79, 50, 8, 0.9),
     -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
     0 0 20px rgba(212, 175, 55, 0.6) !important;
 }
@@ -509,6 +509,17 @@ footer {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+/* Gradient button matching logo colors */
+.btn-gold {
+  background: linear-gradient(135deg, #c8a148, #4f3208);
+  color: #fff;
+}
+
+.btn-gold:hover {
+  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4),
+    0 0 40px rgba(212, 175, 55, 0.2);
 }
 
 /* Floating animation for CTA button */


### PR DESCRIPTION
## Summary
- swap remaining blue hero gradients for gold-to-black tones matching the logo
- introduce reusable `btn-gold` class for CTA buttons across service pages
- adjust hero text shadows so gradient text renders in brand colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e4a34e4832b9bb6162d502861bd