### PR TITLE
Fix service page email links to match homepage

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -40,7 +40,7 @@
           </div>
           <div class="hidden md:flex flex-col ml-4 text-xs text-gray-300">
             <a href="tel:2156038009" class="hover:text-white transition-colors duration-200">(215) 603-8009</a>
-              class="hover:text-white transition-colors duration-200">peterkpaints@gmail.com</a>
+            <a href="mailto:peterkpaint@gmail.com" class="hover:text-white transition-colors duration-200">peterkpaint@gmail.com</a>
           </div>
         </div>
 
@@ -131,14 +131,14 @@
             </svg>
             (215) 603-8009
           </a>
-          <a href="mailto:peterkpaints@gmail.com"
+          <a href="mailto:peterkpaint@gmail.com"
             class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
               </path>
             </svg>
-            peterkpaints@gmail.com
+            peterkpaint@gmail.com
           </a>
         </div>
         <a href="index.html"

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -40,7 +40,7 @@
           </div>
           <div class="hidden md:flex flex-col ml-4 text-xs text-gray-300">
             <a href="tel:2156038009" class="hover:text-white transition-colors duration-200">(215) 603-8009</a>
-              class="hover:text-white transition-colors duration-200">peterkpaints@gmail.com</a>
+            <a href="mailto:peterkpaint@gmail.com" class="hover:text-white transition-colors duration-200">peterkpaint@gmail.com</a>
           </div>
         </div>
 
@@ -131,14 +131,14 @@
             </svg>
             (215) 603-8009
           </a>
-          <a href="mailto:peterkpaints@gmail.com"
+          <a href="mailto:peterkpaint@gmail.com"
             class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
               </path>
             </svg>
-            peterkpaints@gmail.com
+            peterkpaint@gmail.com
           </a>
         </div>
         <a href="index.html"

--- a/gallery.html
+++ b/gallery.html
@@ -218,8 +218,8 @@
           </div>
           <div class="hidden md:flex flex-col ml-4 text-xs text-gray-300">
             <a href="tel:2156038009" class="hover:text-white transition-colors duration-200">(215) 603-8009</a>
-            <a href="mailto:peterkpaints@gmail.com"
-              class="hover:text-white transition-colors duration-200">peterkpaints@gmail.com</a>
+            <a href="mailto:peterkpaint@gmail.com"
+              class="hover:text-white transition-colors duration-200">peterkpaint@gmail.com</a>
           </div>
         </div>
 
@@ -310,14 +310,14 @@
             </svg>
             (215) 603-8009
           </a>
-          <a href="mailto:peterkpaints@gmail.com"
+          <a href="mailto:peterkpaint@gmail.com"
             class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
               </path>
             </svg>
-            peterkpaints@gmail.com
+            peterkpaint@gmail.com
           </a>
         </div>
         <a href="index.html"

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -40,7 +40,7 @@
           </div>
           <div class="hidden md:flex flex-col ml-4 text-xs text-gray-300">
             <a href="tel:2156038009" class="hover:text-white transition-colors duration-200">(215) 603-8009</a>
-            class="hover:text-white transition-colors duration-200">peterkpaints@gmail.com</a>
+            <a href="mailto:peterkpaint@gmail.com" class="hover:text-white transition-colors duration-200">peterkpaint@gmail.com</a>
           </div>
         </div>
 
@@ -131,14 +131,14 @@
             </svg>
             (215) 603-8009
           </a>
-          <a href="mailto:peterkpaints@gmail.com"
+          <a href="mailto:peterkpaint@gmail.com"
             class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
               </path>
             </svg>
-            peterkpaints@gmail.com
+            peterkpaint@gmail.com
           </a>
         </div>
         <a href="index.html"

--- a/remodeling.html
+++ b/remodeling.html
@@ -40,7 +40,7 @@
           </div>
           <div class="hidden md:flex flex-col ml-4 text-xs text-gray-300">
             <a href="tel:2156038009" class="hover:text-white transition-colors duration-200">(215) 603-8009</a>
-              class="hover:text-white transition-colors duration-200">peterkpaints@gmail.com</a>
+            <a href="mailto:peterkpaint@gmail.com" class="hover:text-white transition-colors duration-200">peterkpaint@gmail.com</a>
           </div>
         </div>
 
@@ -131,14 +131,14 @@
             </svg>
             (215) 603-8009
           </a>
-          <a href="mailto:peterkpaints@gmail.com"
+          <a href="mailto:peterkpaint@gmail.com"
             class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
               </path>
             </svg>
-            peterkpaints@gmail.com
+            peterkpaint@gmail.com
           </a>
         </div>
         <a href="index.html"


### PR DESCRIPTION
## Summary
- ensure service pages and gallery show a proper `mailto:peterkpaint@gmail.com` link under the phone number
- align mobile contact email across pages with the homepage address

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae74727994832b9406e8e09457b223