### PR TITLE
feat: make gallery lightbox fullscreen on mobile

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -189,6 +189,18 @@
       opacity: 1;
       transform: translateY(0);
     }
+
+    /* Fullscreen lightbox images on mobile */
+    @media (max-width: 640px) {
+      .lightbox-content {
+        width: 100vw;
+        height: 100vh;
+        max-width: none;
+        max-height: none;
+        object-fit: cover;
+        border-radius: 0;
+      }
+    }
   </style>
 </head>
 

--- a/src/script.js
+++ b/src/script.js
@@ -489,19 +489,25 @@ const initGalleryUI = () => {
 
   let currentImageIndex = 0;
 
-  function openLightbox(index) {
-    currentImageIndex = index;
-    const img = galleryItems[currentImageIndex].querySelector('img');
-    lightboxImg.src = img.src;
-    lightboxImg.alt = img.alt;
-    lightbox.classList.add('active');
-    document.body.style.overflow = 'hidden';
-  }
+    function openLightbox(index) {
+      currentImageIndex = index;
+      const img = galleryItems[currentImageIndex].querySelector('img');
+      lightboxImg.src = img.src;
+      lightboxImg.alt = img.alt;
+      lightbox.classList.add('active');
+      document.body.style.overflow = 'hidden';
+      if (lightbox.requestFullscreen) {
+        lightbox.requestFullscreen().catch(() => {});
+      }
+    }
 
-  function closeLightbox() {
-    lightbox.classList.remove('active');
-    document.body.style.overflow = 'auto';
-  }
+    function closeLightbox() {
+      lightbox.classList.remove('active');
+      document.body.style.overflow = 'auto';
+      if (document.fullscreenElement && document.exitFullscreen) {
+        document.exitFullscreen();
+      }
+    }
 
   function nextImage() {
     currentImageIndex = (currentImageIndex + 1) % galleryItems.length;


### PR DESCRIPTION
## Summary
- make lightbox images fill the mobile viewport with `object-fit: cover`
- enter and exit fullscreen when opening or closing the lightbox

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68affcc7302c832b836a9160cda31b55