### PR TITLE
Add gallery category dropdown

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -81,9 +81,20 @@
                   role="menuitem">Remodeling</a>
               </div>
             </div>
-
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="index.html#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -170,8 +181,18 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
-        <a href="gallery.html"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
+        <div class="relative">
+          <button id="mobile-gallery-button"
+            class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
+            aria-expanded="false" aria-controls="mobile-gallery-menu">
+            Gallery
+            <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </button>
+          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        </div>
         <a href="index.html#contact"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
           Us</a>

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -81,9 +81,20 @@
                   role="menuitem">Remodeling</a>
               </div>
             </div>
-
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="index.html#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -170,8 +181,18 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
-        <a href="gallery.html"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
+        <div class="relative">
+          <button id="mobile-gallery-button"
+            class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
+            aria-expanded="false" aria-controls="mobile-gallery-menu">
+            Gallery
+            <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </button>
+          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        </div>
         <a href="index.html#contact"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
           Us</a>

--- a/gallery.html
+++ b/gallery.html
@@ -298,8 +298,20 @@
               </div>
             </div>
 
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 bg-gradient-to-r from-blue-500/20 to-blue-600/20 border border-blue-500/30">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center bg-gradient-to-r from-blue-500/20 to-blue-600/20 border border-blue-500/30"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="index.html#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -386,8 +398,18 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
-        <a href="gallery.html"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200 bg-gradient-to-r from-blue-500/20 to-blue-600/20">Gallery</a>
+        <div class="relative">
+          <button id="mobile-gallery-button"
+            class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200 bg-gradient-to-r from-blue-500/20 to-blue-600/20"
+            aria-expanded="false" aria-controls="mobile-gallery-menu">
+            Gallery
+            <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </button>
+          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        </div>
         <a href="index.html#contact"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
           Us</a>
@@ -417,7 +439,10 @@
     <!-- Gallery Grid -->
     <section class="pb-20 md:pb-32 relative">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex flex-wrap justify-center gap-4 mb-8 gallery-nav"></div>
+        <div class="mb-8 flex justify-center">
+          <select id="gallery-select"
+            class="gallery-select px-5 py-2 rounded-full text-sm font-medium text-gray-200 bg-white/10 border border-white/20 backdrop-blur-md"></select>
+        </div>
         <div class="gallery-grid fade-in"></div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -168,8 +168,20 @@
                   role="menuitem">Remodeling</a>
               </div>
             </div>
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -258,8 +270,18 @@
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
         </div> <!-- This closes the div.relative for mobile services dropdown -->
       </div>
-      <a href="gallery.html"
-        class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
+      <div class="relative">
+        <button id="mobile-gallery-button"
+          class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
+          aria-expanded="false" aria-controls="mobile-gallery-menu">
+          Gallery
+          <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+            viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+      </div>
       <a href="#contact"
         class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact Us</a>
     </div>

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -82,9 +82,20 @@
                   role="menuitem">Remodeling</a>
               </div>
             </div>
-
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="index.html#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -171,8 +182,18 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
-        <a href="gallery.html"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
+        <div class="relative">
+          <button id="mobile-gallery-button"
+            class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
+            aria-expanded="false" aria-controls="mobile-gallery-menu">
+            Gallery
+            <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </button>
+          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        </div>
         <a href="index.html#contact"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
           Us</a>

--- a/remodeling.html
+++ b/remodeling.html
@@ -81,9 +81,20 @@
                   role="menuitem">Remodeling</a>
               </div>
             </div>
-
-            <a href="gallery.html"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Gallery</a>
+            <div class="relative group dropdown">
+              <button id="desktop-gallery-button"
+                class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center"
+                aria-expanded="false">
+                Gallery
+                <svg class="w-4 h-4 ml-1 transition-transform duration-200" fill="none" stroke="currentColor"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              </button>
+              <div id="desktop-gallery-menu"
+                class="dropdown-menu absolute left-0 top-full w-56 glass-dropdown rounded-xl shadow-xl z-20 py-2 opacity-0 invisible transform translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:visible group-hover:translate-y-0"
+                role="menu"></div>
+            </div>
             <a href="index.html#contact"
               class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
               Us</a>
@@ -170,8 +181,18 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>
         </div>
-        <a href="gallery.html"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Gallery</a>
+        <div class="relative">
+          <button id="mobile-gallery-button"
+            class="w-full text-left block py-3 px-4 text-base text-gray-200 hover:bg-white/10 flex justify-between items-center transition-colors duration-200"
+            aria-expanded="false" aria-controls="mobile-gallery-menu">
+            Gallery
+            <svg class="w-5 h-5 inline transform transition-transform duration-200" fill="none" stroke="currentColor"
+              viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </button>
+          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        </div>
         <a href="index.html#contact"
           class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
           Us</a>


### PR DESCRIPTION
## Summary
- Add gallery category dropdowns to desktop and mobile navigation
- Filter gallery via category select with URL query support

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3f639cf10832bbb8752a6c9a3d854