### PR TITLE
Add hero slides to service pages

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -200,8 +200,25 @@
   </header>
 
   <main class="relative z-10">
-    <!-- Service Hero Section -->
-    <section class="service-hero text-white" style="background-image: url('src/assets/gallery/painting_305.jpeg');">
+    <!-- Service Hero Section with Slideshow -->
+    <section class="hero-bg service-hero text-white">
+      <div class="hero-slideshow">
+        <div class="hero-slide active" style="background-image: url('src/assets/gallery/Carpentry/capentry_0001.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Carpentry/capentry_0002.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Carpentry/capentry_0003.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Carpentry/capentry_0004.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Carpentry/capentry_0005.jpeg');"></div>
+      </div>
+
+      <!-- Slideshow indicators -->
+      <div class="slideshow-indicators">
+        <div class="indicator glass-indicator active" data-slide="0"></div>
+        <div class="indicator glass-indicator" data-slide="1"></div>
+        <div class="indicator glass-indicator" data-slide="2"></div>
+        <div class="indicator glass-indicator" data-slide="3"></div>
+        <div class="indicator glass-indicator" data-slide="4"></div>
+      </div>
+
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -200,8 +200,25 @@
   </header>
 
   <main class="relative z-10">
-    <!-- Service Hero Section -->
-    <section class="service-hero text-white" style="background-image: url('src/assets/gallery/painting_20.jpeg');">
+    <!-- Service Hero Section with Slideshow -->
+    <section class="hero-bg service-hero text-white">
+      <div class="hero-slideshow">
+        <div class="hero-slide active" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0001.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0002.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0003.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0004.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0005.jpeg');"></div>
+      </div>
+
+      <!-- Slideshow indicators -->
+      <div class="slideshow-indicators">
+        <div class="indicator glass-indicator active" data-slide="0"></div>
+        <div class="indicator glass-indicator" data-slide="1"></div>
+        <div class="indicator glass-indicator" data-slide="2"></div>
+        <div class="indicator glass-indicator" data-slide="3"></div>
+        <div class="indicator glass-indicator" data-slide="4"></div>
+      </div>
+
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">

--- a/remodeling.html
+++ b/remodeling.html
@@ -200,8 +200,25 @@
   </header>
 
   <main class="relative z-10">
-    <!-- Service Hero Section -->
-    <section class="service-hero text-white" style="background-image: url('src/assets/gallery/painting_116.jpeg');">
+    <!-- Service Hero Section with Slideshow -->
+    <section class="hero-bg service-hero text-white">
+      <div class="hero-slideshow">
+        <div class="hero-slide active" style="background-image: url('src/assets/gallery/Remodeling/[1] remodel_12-2022.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Remodeling/[2] remodel_12-2022.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Remodeling/[3] remodel_12-2022.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Remodeling/[4] remodel_12-2022.jpeg');"></div>
+        <div class="hero-slide" style="background-image: url('src/assets/gallery/Remodeling/[5] remodel_12-2022.jpeg');"></div>
+      </div>
+
+      <!-- Slideshow indicators -->
+      <div class="slideshow-indicators">
+        <div class="indicator glass-indicator active" data-slide="0"></div>
+        <div class="indicator glass-indicator" data-slide="1"></div>
+        <div class="indicator glass-indicator" data-slide="2"></div>
+        <div class="indicator glass-indicator" data-slide="3"></div>
+        <div class="indicator glass-indicator" data-slide="4"></div>
+      </div>
+
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
- Add reusable hero slideshow to Exterior Painting page with category-specific images
- Integrate hero slideshow into Carpentry page using Carpentry gallery photos
- Enable hero slideshow on Remodeling page with Remodeling gallery images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bd2a1558832bb994914f78c06508