### PR TITLE
feat: refine hero title outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,15 +314,14 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <!-- Main hero card -->
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
-            <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              <span class="gradient-text">PK Paints &amp; Renovations</span>
+            <h1
+              class="text-5xl sm:text-6xl md:text-7xl font-extrabold mb-8 leading-tight w-fit mx-auto">
+              <span class="gradient-text hero-title-outline-subtle">PK Paints &amp; Renovations</span>
+              <!-- Swap hero-title-outline-subtle with hero-title-outline-strong for a bolder option -->
             </h1>
-            <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              <br />
-              The <span class='gradient-text'>golden</span> standard in quality.
-              <br />
-              <br />
-              Premium spray finishes.
+            <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
+              Custom <span class="gradient-text">trim work</span><br />
+              Premium <span class="gradient-text">spray finishes</span>.
             </p>
             <a href="#contact"
               class="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">

--- a/src/style.css
+++ b/src/style.css
@@ -160,32 +160,16 @@ body {
   backdrop-filter: blur(1px);
 }
 
-/* Add text shadows to hero text for better readability */
-.glass-card-hero h1,
-.glass-card-hero p {
-  text-shadow: 2px 2px 0px black, -2px -2px 0px black, 2px -2px 0px black,
-    -2px 2px 0px black, 1px 1px 0px black, -1px -1px 0px black,
-    1px -1px 0px black, -1px 1px 0px black, 4px 4px 8px black,
-    0 0 10px rgba(255, 255, 255, 0.5) !important;
-  color: white !important;
-  font-weight: 700 !important;
+/* Hero title outline variations */
+.hero-title-outline-subtle {
+  -webkit-text-stroke: 1px #000;
+  filter: drop-shadow(0 0 6px rgba(212, 175, 55, 0.6));
 }
 
-/* Specifically target the main hero heading */
-.glass-card-hero h1 {
-  text-shadow: 2px 2px 0px black, -2px -2px 0px black, 2px -2px 0px black,
-    -2px 2px 0px black, 1px 1px 0px black, -1px -1px 0px black,
-    1px -1px 0px black, -1px 1px 0px black, 4px 4px 8px black,
-    0 0 10px rgba(255, 255, 255, 0.5) !important;
-  color: white !important;
-  font-weight: 700 !important;
-}
-
-.glass-card-hero h1 .gradient-text {
-  text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
-    -1px -1px 0px rgba(200, 161, 72, 0.9), 1px -1px 0px rgba(79, 50, 8, 0.9),
-    -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
-    0 0 20px rgba(212, 175, 55, 0.6) !important;
+.hero-title-outline-strong {
+  -webkit-text-stroke: 1px #000;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.6),
+    0 0 12px rgba(212, 175, 55, 0.7);
 }
 .glass-card-hero p .gradient-text {
   /* Add custom text-shadow properties here if desired */


### PR DESCRIPTION
## Summary
- replace hero tagline with italic small text highlighting custom trim work and premium spray finishes
- lighten hero title with subtle black stroke and gold glow, plus optional stronger variant

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d537b3e4832b8a85ba48dc1bd69e