### PR TITLE
Use contain for hero backgrounds

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -100,7 +100,8 @@ body {
 /* Hero section with slideshow background */
 .hero-bg {
   position: relative;
-  background-size: cover;
+  background-size: contain;
+  background-repeat: no-repeat;
   background-position: center;
   background-attachment: fixed;
   overflow: hidden;
@@ -126,7 +127,8 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background-size: cover;
+  background-size: contain;
+  background-repeat: no-repeat;
   background-position: center;
   background-attachment: fixed;
   opacity: 0;
@@ -268,7 +270,8 @@ body {
 .service-hero {
   position: relative;
   min-height: 100vh;
-  background-size: cover;
+  background-size: contain;
+  background-repeat: no-repeat;
   background-position: center;
   background-attachment: fixed;
   display: flex;


### PR DESCRIPTION
## Summary
- avoid zoomed-in hero images by using `background-size: contain` and `background-repeat: no-repeat`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba350421dc832b877651c30978e4c0