### PR TITLE
Remove glass-card hero styling

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -221,7 +221,7 @@
 
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
+          <div class="rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Custom <span class="gradient-text">Carpentry</span>
             </h1>

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -221,7 +221,7 @@
 
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
+          <div class="rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Expert <span class="gradient-text">Exterior Painting</span>
             </h1>

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <!-- Main hero card -->
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
+          <div class="rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               <span class="gradient-text">PK Paints &amp; Renovations</span>
             </h1>

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -226,7 +226,7 @@
 
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
+          <div class="rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               <span class="gradient-text">Interior Painting</span>
             </h1>

--- a/remodeling.html
+++ b/remodeling.html
@@ -221,7 +221,7 @@
 
       <div class="service-hero-content">
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
+          <div class="rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Comprehensive <span class="gradient-text">Remodeling</span>
             </h1>

--- a/src/style.css
+++ b/src/style.css
@@ -316,11 +316,11 @@ body {
 
 /* Glass hero card for service pages */
 .service-hero .glass-card-hero {
-  background: rgba(255, 255, 255, 0.08) !important;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4);
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+  box-shadow: none;
 }
 
 /* Service hero text shadows */
@@ -348,7 +348,11 @@ body {
   }
 
   .service-hero .glass-card-hero {
-    background: rgba(255, 255, 255, 0.12) !important;
+    background: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border: none;
+    box-shadow: none;
   }
 
   .service-hero .glass-card-hero h1,


### PR DESCRIPTION
## Summary
- remove glass-card hero styles to eliminate translucent box
- drop `glass-card-hero` class from service hero sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7255f0e4832bbf4deb648a8b834b