### PR TITLE
Refine hero text without glass box

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -201,7 +201,7 @@ body {
   background: none !important; /* Remove the big dark block */
   backdrop-filter: none !important;
   border: none !important;
-  box-shadow: none !important;
+  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4) !important;
   padding: 2rem !important; /* Reduce padding so it's not so massive */
 }
 
@@ -316,10 +316,10 @@ body {
 
 /* Glass hero card for service pages */
 .service-hero .glass-card-hero {
-  background: rgba(255, 255, 255, 0.08) !important;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
   box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4);
 }
 
@@ -348,7 +348,11 @@ body {
   }
 
   .service-hero .glass-card-hero {
-    background: rgba(255, 255, 255, 0.12) !important;
+    background: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border: none;
+    box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4);
   }
 
   .service-hero .glass-card-hero h1,


### PR DESCRIPTION
## Summary
- drop translucent background from `.glass-card-hero` while retaining drop-shadow
- restore `glass-card-hero` wrapper on home and service hero sections to keep text shadows

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7255f0e4832bbf4deb648a8b834b