### PR TITLE
Fix invalid preload image references

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,10 @@
 import './style.css';
 import { buildGallery } from './gallery-builder.js';
+import heroImage1 from './assets/hero/[21] interior_04-2021.jpeg';
+import heroImage2 from './assets/hero/[67] interior_11-2022.jpeg';
+import exterior from './assets/exterior.png';
+import dine from './assets/dine.png';
+import dine2 from './assets/dine2.png';
 
 const galleryDataPromise = buildGallery();
 let lightboxInitialized = false;
@@ -434,12 +439,7 @@ const initGalleryEnhancements = () => {
   });
 
   // Preload critical gallery images
-  const preloadImages = [
-    'assets/gallery/showers_35.jpg',
-    'assets/gallery/shower-2.jpg',
-    'assets/gallery/doors_03.jpg',
-    'assets/gallery/railing_04.jpg',
-  ];
+  const preloadImages = [heroImage1, heroImage2, exterior, dine, dine2];
 
   preloadImages.forEach((src) => {
     const link = document.createElement('link');


### PR DESCRIPTION
## Summary
- import hero and featured images
- preload existing image assets instead of missing ones

## Testing
- `npm test`
- `npm run build`
- `node -e "const fs=require('fs'); const images=['src/assets/hero/[21] interior_04-2021.jpeg','src/assets/hero/[67] interior_11-2022.jpeg','src/assets/exterior.png','src/assets/dine.png','src/assets/dine2.png']; images.forEach(i=>console.log(i, fs.existsSync(i)));"`


------
https://chatgpt.com/codex/tasks/task_e_68be456f7198832bb61f3be68a4ab16b