### PR TITLE
Highlight active navigation links

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -121,6 +121,31 @@ document.addEventListener('DOMContentLoaded', async () => {
       .join('');
   }
 
+  // Highlight current navigation link
+  const currentPath =
+    window.location.pathname.split('/').pop() || 'index.html';
+  document.querySelectorAll('nav a, #mobile-menu a').forEach((link) => {
+    const href = link.getAttribute('href');
+    if (
+      !href ||
+      href.startsWith('#') ||
+      href.startsWith('mailto:') ||
+      href.startsWith('tel:')
+    ) {
+      return;
+    }
+    const linkPath = new URL(href, window.location.origin).pathname
+      .split('/')
+      .pop();
+    if (linkPath === currentPath) {
+      link.classList.add('active');
+    }
+  });
+  if (currentPath === 'gallery.html') {
+    if (desktopGalleryButton) desktopGalleryButton.classList.add('active');
+    if (mobileGalleryButton) mobileGalleryButton.classList.add('active');
+  }
+
   if (mobileMenuButton && mobileMenu) {
     mobileMenuButton.addEventListener('click', () => {
       const isExpanded = mobileMenu.classList.toggle('hidden');

--- a/src/style.css
+++ b/src/style.css
@@ -90,6 +90,15 @@ body {
   font-weight: 500 !important;
 }
 
+nav a.active,
+#mobile-menu a.active,
+nav button.active,
+#mobile-menu button.active {
+  font-weight: 700;
+  text-decoration: underline;
+  color: #fbbf24 !important;
+}
+
 /* Style for the mobile products dropdown arrow rotation */
 #mobile-services-button[aria-expanded='true'] svg {
   transform: rotate(180deg);


### PR DESCRIPTION
## Summary
- Highlight the current page's navigation link based on location pathname
- Style active nav items with bold, underlined, yellow text for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4f0cd044832b80f86d5985d3aeed