### PR TITLE
Fix hero images and streamline service hero text

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -225,10 +225,9 @@
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Custom <span class="gradient-text">Carpentry</span>
             </h1>
-            <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Enhance your home with quality woodwork, trim, and repairs
-              crafted to fit your style and needs.
-            </p>
+              <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
+                Craftsmanship in every cut.
+              </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
                 class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -203,11 +203,11 @@
     <!-- Service Hero Section with Slideshow -->
     <section class="hero-bg service-hero text-white">
       <div class="hero-slideshow">
-        <div class="hero-slide active" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0001.jpeg');"></div>
-        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0002.jpeg');"></div>
-        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0003.jpeg');"></div>
-        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0004.jpeg');"></div>
-        <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/exteriorl_0005.jpeg');"></div>
+          <div class="hero-slide active" style="background-image: url('src/assets/gallery/Exterior Painting/[1]exterior_06-2021.jpeg');"></div>
+          <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/[2]exterior_06-2021.jpeg');"></div>
+          <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/[3]exterior_06-2021.jpeg');"></div>
+          <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/[4]exterior_06-2021.jpeg');"></div>
+          <div class="hero-slide" style="background-image: url('src/assets/gallery/Exterior Painting/[5]exterior_06-2021.jpeg');"></div>
       </div>
 
       <!-- Slideshow indicators -->
@@ -225,10 +225,9 @@
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Expert <span class="gradient-text">Exterior Painting</span>
             </h1>
-            <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Protect and beautify your home with long-lasting finishes
-              designed to withstand the elements.
-            </p>
+              <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
+                Weather-ready, lasting color.
+              </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
                 class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">

--- a/gallery.html
+++ b/gallery.html
@@ -418,7 +418,7 @@
 
   <main class="relative z-10">
     <!-- Gallery Hero Section -->
-    <section class="service-hero text-white" style="background-image: url('src/assets/gallery/painting_207.jpeg');">
+    <section class="service-hero text-white" style="background-image: url('src/assets/painting_162.png');">
     </section>
 
     <!-- Gallery Grid -->

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -205,15 +205,15 @@
     <section class="hero-bg service-hero text-white">
       <div class="hero-slideshow">
         <div class="hero-slide active"
-          style="background-image: url('src/assets/interior/[97]\ interior_06-2023.jpeg');"></div>
+          style="background-image: url('src/assets/interior/[97] interior_06-2023.jpeg');"></div>
         <div class="hero-slide"
-          style="background-image: url('src/assets/gallery/Interior Painting/interior_0001.jpeg');"></div>
+          style="background-image: url('src/assets/gallery/Interior Painting/[1] interior_11-2020.jpeg');"></div>
         <div class="hero-slide"
-          style="background-image: url('src/assets/gallery/Interior Painting/interior_0034.jpeg');"></div>
+          style="background-image: url('src/assets/gallery/Interior Painting/[2] interior_11-2020.jpeg');"></div>
         <div class="hero-slide"
-          style="background-image: url('src/assets/gallery/Interior Painting/interior_0067.jpeg');"></div>
+          style="background-image: url('src/assets/gallery/Interior Painting/[3] interior_11-2020.jpeg');"></div>
         <div class="hero-slide"
-          style="background-image: url('src/assets/gallery/Interior Painting/interior_0100.jpeg');"></div>
+          style="background-image: url('src/assets/gallery/Interior Painting/[4] interior_03-2021.jpeg');"></div>
       </div>
 
       <!-- Slideshow indicators -->
@@ -231,8 +231,8 @@
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               <span class="gradient-text">Interior Painting</span>
             </h1>
-            <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Refresh your place with crisp lines and smooth finishes that last.
+            <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
+              Crisp lines &amp; smooth finishes.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"

--- a/remodeling.html
+++ b/remodeling.html
@@ -225,10 +225,9 @@
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
               Comprehensive <span class="gradient-text">Remodeling</span>
             </h1>
-            <p class="text-xl sm:text-2xl md:text-3xl mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Transform your space with expert renovations tailored to your
-              vision and lifestyle.
-            </p>
+              <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
+                Renovations tailored to you.
+              </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="index.html#contact"
                 class="btn-gold text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-300">


### PR DESCRIPTION
## Summary
- Restore missing hero backgrounds for interior and exterior painting pages and the gallery page
- Shorten hero copy on service pages for a cleaner look ahead of new marketing text

## Testing
- `npm test` *(fails: 'no-unused-vars' and 'no-undef' in src/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc639a3c0832bbec826579f21b1d9