### PR TITLE
Replace carpentry references with custom installs

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -253,11 +253,11 @@
           <div>
             <div class="glass-card stack-layer rounded-2xl p-8">
               <h2 class="text-4xl lg:text-5xl font-bold text-white mb-8">
-                Why Choose Our <span class="gradient-text">Carpentry Services</span>?
+                Why Choose Our <span class="gradient-text">Custom Install Services</span>?
               </h2>
               <div class="space-y-6 text-gray-300 text-lg leading-relaxed">
                 <p>
-                  From custom builds to detailed repairs, our carpenters bring
+                  From custom builds to detailed repairs, our installation experts bring
                   craftsmanship and care to every project.
                 </p>
                 <ul class="space-y-4">
@@ -288,7 +288,7 @@
           </div>
           <div>
             <div class="gallery-item float-2">
-              <img src="assets/stain_door.png" alt="Custom carpentry project"
+              <img src="assets/stain_door.png" alt="Custom install project"
                 class="rounded-2xl shadow-2xl w-full h-auto object-cover"
                 onerror="this.src='https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1000&q=80';" />
             </div>

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -75,7 +75,7 @@
                   role="menuitem">Exterior Painting</a>
                 <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Carpentry</a>
+                  role="menuitem">Custom Installs</a>
                 <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
@@ -176,7 +176,7 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior
               Painting</a>
             <a href="carpentry.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Custom Installs</a>
             <a href="remodeling.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>

--- a/gallery.html
+++ b/gallery.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gallery | PK Paints n' Renovations - Frameless Glass Solutions</title>
   <meta name="description"
-    content="Explore our portfolio of interior and exterior painting, carpentry, and remodeling projects." />
+    content="Explore our portfolio of interior and exterior painting, custom installs, and remodeling projects." />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="src/style.css" />
@@ -303,7 +303,7 @@
                   role="menuitem">Exterior Painting</a>
                 <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Carpentry</a>
+                  role="menuitem">Custom Installs</a>
                 <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
@@ -405,7 +405,7 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior
               Painting</a>
             <a href="carpentry.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Custom Installs</a>
             <a href="remodeling.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>

--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PK Paints & Renovations</title>
   <meta name="description"
-    content="Professional painting, carpentry, and renovation services for homes and businesses." />
+    content="Professional painting, custom installs, and renovation services for homes and businesses." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://www.pkpaints.com/" />
-  <meta property="og:title" content="PK Paints & Renovations - Painting, Trim Work, &amp; Renovations" />
+  <meta property="og:title" content="PK Paints & Renovations - Painting, Custom Installs, &amp; Renovations" />
   <meta property="og:description"
     content="Serving the tri-state area with quality painting and remodeling solutions." />
   <meta property="og:image" content="assets/icons/logo.png" />
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://www.pkpaints.com/" />
   <meta property="twitter:title" content="PK Paints & Renovations" />
-  <meta property="twitter:description" content="Your trusted partner for painting and custom trimwork." />
+  <meta property="twitter:description" content="Your trusted partner for painting and custom installs." />
   <meta property="twitter:image" content="assets/brand-logo.png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -39,7 +39,7 @@
         "@id": "https://www.pkpaints.com/",
         "url": "https://www.pkpaints.com/",
         "telephone": "+1-215-603-8009",
-        "description": "PK Paints n' Renovations provides professional painting, carpentry and remodeling services with meticulous attention to detail.",
+        "description": "PK Paints n' Renovations provides professional painting, custom installs and remodeling services with meticulous attention to detail.",
         "address": {
           "@type": "PostalAddress",
           "streetAddress": "123 Main Street",
@@ -162,7 +162,7 @@
                   role="menuitem">Exterior Painting</a>
                 <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Custom Trimwork</a>
+                  role="menuitem">Custom Installs</a>
                 <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
@@ -515,7 +515,7 @@
               </div>
               <h3
                 class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
-                Trim Work
+                Custom Installs
               </h3>
               <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
                 Custom installs & repairs

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -76,7 +76,7 @@
                   role="menuitem">Exterior Painting</a>
                 <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Carpentry</a>
+                  role="menuitem">Custom Installs</a>
                 <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
@@ -177,7 +177,7 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior
               Painting</a>
             <a href="carpentry.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Custom Installs</a>
             <a href="remodeling.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>

--- a/public/gallery.json
+++ b/public/gallery.json
@@ -1,5 +1,5 @@
 {
-  "Carpentry": [
+  "Custom Installs": [
     "src/assets/gallery/Carpentry/capentry_0001.jpeg",
     "src/assets/gallery/Carpentry/capentry_0002.jpeg",
     "src/assets/gallery/Carpentry/capentry_0003.jpeg",
@@ -99,7 +99,8 @@
     "src/assets/gallery/Carpentry/capentry_0097.jpeg",
     "src/assets/gallery/Carpentry/capentry_0098.jpeg",
     "src/assets/gallery/Carpentry/capentry_0099.jpeg",
-    "src/assets/gallery/Carpentry/capentry_0100.jpeg"
+    "src/assets/gallery/Carpentry/capentry_0100.jpeg",
+    "src/assets/gallery/Carpentry/cover.jpeg"
   ],
   "Commercial": [
     "src/assets/gallery/Commercial/commercial_0001.jpeg",

--- a/remodeling.html
+++ b/remodeling.html
@@ -75,7 +75,7 @@
                   role="menuitem">Exterior Painting</a>
                 <a href="carpentry.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
-                  role="menuitem">Carpentry</a>
+                  role="menuitem">Custom Installs</a>
                 <a href="remodeling.html"
                   class="block px-4 py-3 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200 rounded-lg mx-2"
                   role="menuitem">Remodeling</a>
@@ -176,7 +176,7 @@
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Exterior
               Painting</a>
             <a href="carpentry.html"
-              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Carpentry</a>
+              class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Custom Installs</a>
             <a href="remodeling.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Remodeling</a>
           </div>

--- a/scripts/generate-gallery-json.js
+++ b/scripts/generate-gallery-json.js
@@ -12,14 +12,15 @@ function collectImagesByCategory(dir) {
 
   const categories = {};
   for (const entry of entries) {
-    const category = entry.name;
+    const folderName = entry.name;
+    const category = folderName === 'Carpentry' ? 'Custom Installs' : folderName;
     const files = fs
-      .readdirSync(path.join(dir, category))
+      .readdirSync(path.join(dir, folderName))
       .filter((file) => ['.jpg', '.jpeg', '.png', '.webp'].includes(path.extname(file).toLowerCase()))
       .sort();
 
     if (files.length > 0) {
-      categories[category] = files.map((file) => `src/assets/gallery/${category}/${file}`);
+      categories[category] = files.map((file) => `src/assets/gallery/${folderName}/${file}`);
     }
   }
   return categories;

--- a/src/gallery-builder.js
+++ b/src/gallery-builder.js
@@ -33,14 +33,15 @@ export async function buildGallery() {
       // Ignore root level painting_### images
       if (fileName.startsWith('painting_')) continue;
 
-      const galleryIdx = parts.indexOf('gallery');
-      const categoryName = parts[galleryIdx + 1];
-      if (!categoryName || categoryName.startsWith('painting_')) continue;
+        const galleryIdx = parts.indexOf('gallery');
+        const categoryName = parts[galleryIdx + 1];
+        if (!categoryName || categoryName.startsWith('painting_')) continue;
 
-      const slug = categoryName.toLowerCase().replace(/\s+/g, '-');
-      categoriesSet.add(JSON.stringify({ name: categoryName, slug }));
-      if (!imagesByCategory[slug]) imagesByCategory[slug] = [];
-      imagesByCategory[slug].push(url);
+        const displayName = categoryName === 'Carpentry' ? 'Custom Installs' : categoryName;
+        const slug = displayName.toLowerCase().replace(/\s+/g, '-');
+        categoriesSet.add(JSON.stringify({ name: displayName, slug }));
+        if (!imagesByCategory[slug]) imagesByCategory[slug] = [];
+        imagesByCategory[slug].push(url);
       // Detect a cover image if file named like cover.* exists
       const isCover = /(^|\/)cover\.(jpg|jpeg|png|webp)(\?|$)/i.test(fileName);
       if (isCover) coverByCategory[slug] = url;
@@ -51,10 +52,11 @@ export async function buildGallery() {
       const res = await fetch('gallery.json');
       if (res.ok) {
         const data = await res.json();
-        for (const categoryName in data) {
-          const slug = categoryName.toLowerCase().replace(/\s+/g, '-');
-          categoriesSet.add(JSON.stringify({ name: categoryName, slug }));
-          imagesByCategory[slug] = data[categoryName];
+          for (const categoryName in data) {
+            const displayName = categoryName === 'Carpentry' ? 'Custom Installs' : categoryName;
+            const slug = displayName.toLowerCase().replace(/\s+/g, '-');
+            categoriesSet.add(JSON.stringify({ name: displayName, slug }));
+            imagesByCategory[slug] = data[categoryName];
           // If any file name within the list matches cover.* use it as cover
           const cover = (data[categoryName] || []).find((p) =>
             /(^|\/)cover\.(jpg|jpeg|png|webp)(\?|$)/i.test(p)

--- a/src/style.css
+++ b/src/style.css
@@ -295,8 +295,8 @@ nav button.active,
 .exterior-hero {
   background-image: url('/assets/exterior.png');
 }
-/* Carpentry specific background */
-.carpentry-hero {
+/* Custom installs specific background */
+.custom-installs-hero {
   background-image: url('/assets/stain_door.png');
 }
 /* Remodeling specific background */

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,10 +12,10 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         gallery: resolve(__dirname, 'gallery.html'),
-        'exterior-painting': resolve(__dirname, 'exterior-painting.html'),
-        carpentry: resolve(__dirname, 'carpentry.html'),
-        remodeling: resolve(__dirname, 'remodeling.html'),
-        'interior-painting': resolve(__dirname, 'interior-painting.html'),
+          'exterior-painting': resolve(__dirname, 'exterior-painting.html'),
+          'custom-installs': resolve(__dirname, 'carpentry.html'),
+          remodeling: resolve(__dirname, 'remodeling.html'),
+          'interior-painting': resolve(__dirname, 'interior-painting.html'),
       },
       output: {
         assetFileNames: 'assets/[name]-[hash].[ext]',


### PR DESCRIPTION
## Summary
- Rename carpentry service to "Custom Installs" across site navigation and metadata
- Update custom installs page copy and gallery category
- Adjust build config and scripts to handle renamed service

## Testing
- `npm run generate:gallery`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a818f654832bbadc645b839ca45c