### PR TITLE
Align service hero titles with navigation

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -231,7 +231,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Custom <span class="gradient-text">Installs</span>
+              <span class="gradient-text">Custom Installs</span>
             </h1>
             <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
               Craftsmanship in every cut.

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -228,7 +228,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Expert <span class="gradient-text">Exterior Painting</span>
+              <span class="gradient-text">Exterior Painting</span>
             </h1>
               <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
                 Weather-ready, lasting color.

--- a/remodeling.html
+++ b/remodeling.html
@@ -228,7 +228,7 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
             <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              Comprehensive <span class="gradient-text">Remodeling</span>
+              <span class="gradient-text">Remodeling</span>
             </h1>
               <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
                 Renovations tailored to you.


### PR DESCRIPTION
## Summary
- match each service page hero title to its navigation label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c68951804c832bae3ea393afc4f7b2