### PR TITLE
Align service page accents with golden brand palette

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -139,7 +139,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -148,7 +148,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -267,21 +267,21 @@
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Trim and molding installation</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Built-in shelving and storage solutions</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
@@ -310,7 +310,7 @@
         <a href="https://www.facebook.com/pkpaints" target="_blank" rel="noopener noreferrer"
           class="glass-card inline-flex items-center justify-center w-12 h-12 rounded-full hover-glass transition-colors duration-300"
           aria-label="PK Paints n' Renovations on Facebook">
-          <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg class="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path fill-rule="evenodd"
               d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
               clip-rule="evenodd" />

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -138,7 +138,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -147,7 +147,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -264,21 +264,21 @@
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Thorough surface prep and power washing</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Weather-resistant coatings for lasting protection</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
@@ -307,7 +307,7 @@
         <a href="https://www.facebook.com/pkpaints" target="_blank" rel="noopener noreferrer"
           class="glass-card inline-flex items-center justify-center w-12 h-12 rounded-full hover-glass transition-colors duration-300"
           aria-label="PK Paints n' Renovations on Facebook">
-          <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg class="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path fill-rule="evenodd"
               d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
               clip-rule="evenodd" />

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -139,7 +139,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -148,7 +148,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -271,21 +271,21 @@
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Careful prep work for clean, sharp results</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Premium paints for vibrant, durable color</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
@@ -313,7 +313,7 @@
         <a href="https://www.facebook.com/pkpaints" target="_blank" rel="noopener noreferrer"
           class="glass-card inline-flex items-center justify-center w-12 h-12 rounded-full hover-glass transition-colors duration-300"
           aria-label="PK Paints n' Renovations on Facebook">
-          <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg class="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path fill-rule="evenodd"
               d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
               clip-rule="evenodd" />

--- a/remodeling.html
+++ b/remodeling.html
@@ -138,7 +138,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -147,7 +147,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -264,21 +264,21 @@
                 </p>
                 <ul class="space-y-4">
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Kitchen and bathroom upgrades</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
                     <span>Flooring and layout improvements</span>
                   </li>
                   <li class="flex items-start">
-                    <svg class="w-6 h-6 text-blue-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
+                    <svg class="w-6 h-6 text-yellow-400 mr-3 mt-1 flex-shrink-0" fill="none" stroke="currentColor"
                       viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                     </svg>
@@ -307,7 +307,7 @@
         <a href="https://www.facebook.com/pkpaints" target="_blank" rel="noopener noreferrer"
           class="glass-card inline-flex items-center justify-center w-12 h-12 rounded-full hover-glass transition-colors duration-300"
           aria-label="PK Paints n' Renovations on Facebook">
-          <svg class="w-6 h-6 text-blue-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg class="w-6 h-6 text-yellow-400" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path fill-rule="evenodd"
               d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
               clip-rule="evenodd" />


### PR DESCRIPTION
## Summary
- update service page mobile contact links to use the golden brand palette
- refresh bullet icons and footer social icon colors to the golden accent
- ensure Facebook footer links across services match the home page styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9000b06e4832b8853d92c16d078c2