### PR TITLE
Revamp homepage design and unify navigation ctas

### DIFF
--- a/carpentry.html
+++ b/carpentry.html
@@ -97,8 +97,7 @@
                 role="menu"></div>
             </div>
             <a href="index.html#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <div class="hidden md:flex items-center space-x-3 ml-4">
@@ -139,7 +138,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -148,7 +147,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -169,7 +168,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
             <a href="interior-painting.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
               Painting</a>
@@ -193,11 +192,11 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+          <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
+      </div>
+        <div class="px-4 pt-3 pb-5">
+          <a href="index.html#contact" class="mobile-cta">Get a Quote</a>
         </div>
-        <a href="index.html#contact"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
-          Us</a>
       </div>
   </header>
 

--- a/exterior-painting.html
+++ b/exterior-painting.html
@@ -96,8 +96,7 @@
                 role="menu"></div>
             </div>
             <a href="index.html#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <div class="hidden md:flex items-center space-x-3 ml-4">
@@ -138,7 +137,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -147,7 +146,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -168,7 +167,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
             <a href="interior-painting.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
               Painting</a>
@@ -191,11 +190,11 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+          <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
+      </div>
+        <div class="px-4 pt-3 pb-5">
+          <a href="index.html#contact" class="mobile-cta">Get a Quote</a>
         </div>
-        <a href="index.html#contact"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
-          Us</a>
       </div>
   </header>
 

--- a/gallery.html
+++ b/gallery.html
@@ -325,8 +325,7 @@
                 role="menu"></div>
             </div>
             <a href="index.html#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <div class="hidden md:flex items-center space-x-3 ml-4">
@@ -367,7 +366,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -376,7 +375,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -397,7 +396,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
             <a href="interior-painting.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
               Painting</a>
@@ -420,11 +419,11 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+          <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
         </div>
-        <a href="index.html#contact"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
-          Us</a>
+      <div class="px-4 pt-3 pb-5">
+        <a href="index.html#contact" class="mobile-cta">Get a Quote</a>
+      </div>
       </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -72,23 +72,6 @@
   -->
 
   <link rel="stylesheet" href="src/style.css" />
-  <style>
-    /* Mobile Service Links */
-    .mobile-service-link {
-      background: rgba(255, 255, 255, 0.05);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      transition: all 0.3s ease;
-    }
-
-    .mobile-service-link:hover {
-      background: rgba(255, 255, 255, 0.1);
-      border-color: rgba(245, 158, 11, 0.4);
-      /* amber-500 with opacity */
-      transform: translateY(-2px);
-    }
-  </style>
 </head>
 
 <body class="bg-gray-950 text-gray-200 antialiased font-inter">
@@ -183,8 +166,7 @@
                 role="menu"></div>
             </div>
             <a href="#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <!-- Desktop Social Icons -->
@@ -227,7 +209,7 @@
       <!-- Contact Info Section for Mobile -->
       <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
         <a href="tel:2156038009"
-          class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
+          class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
           <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -236,7 +218,7 @@
           (215) 603-8009
         </a>
         <a href="mailto:peterkpaint@gmail.com"
-          class="flex items-center text-sm text-yellow-400 hover:text-yellow-300 transition-colors duration-200">
+          class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
           <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -257,7 +239,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
-        <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+        <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
           <a href="interior-painting.html"
             class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
             Painting</a>
@@ -281,10 +263,11 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
-        <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+        <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
       </div>
-      <a href="#contact"
-        class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact Us</a>
+      <div class="px-4 pt-3 pb-5">
+        <a href="#contact" class="mobile-cta">Get a Quote</a>
+      </div>
     </div>
   </header>
 
@@ -300,6 +283,8 @@
         <div class="hero-slide"></div>
       </div>
 
+      <div class="hero-overlay"></div>
+
 
       <!-- Slideshow indicators (dots) with glass effect -->
       <div class="slideshow-indicators">
@@ -312,20 +297,74 @@
 
       <!-- Hero Content -->
       <div class="service-hero-content">
-        <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <!-- Main hero card -->
-          <div class="glass-card-hero rounded-3xl p-12 max-w-4xl mx-auto">
-            <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold mb-8 leading-tight">
-              <span class="gradient-text">PK Paints &amp; Renovations</span>
-            </h1>
-            <p class="text-base sm:text-lg italic mb-12 text-gray-200 max-w-3xl mx-auto leading-relaxed">
-              Custom <span class="gradient-text">trim work</span><br />
-              Premium <span class="gradient-text">spray finishes</span>.
-            </p>
-            <a href="#contact"
-              class="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white px-8 py-4 rounded-xl font-semibold hover:shadow-lg transition-all duration-600">
-              Get Free Quote
-            </a>
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="max-w-5xl mx-auto flex flex-col gap-8">
+            <div class="glass-card-hero rounded-[2rem] max-w-4xl mx-auto text-center md:text-left">
+              <div class="flex flex-col gap-6">
+                <span class="hero-eyebrow">Signature finishes &amp; renovations</span>
+                <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold leading-tight">
+                  <span class="gradient-text">PK Paints &amp; Renovations</span>
+                </h1>
+                <p class="hero-subtitle max-w-3xl mx-auto md:mx-0">
+                  From meticulous prep to flawless finishes, our team delivers elevated interior and exterior painting,
+                  custom installs, and cabinetry refinishing that stand the test of time.
+                </p>
+                <div class="hero-actions">
+                  <a href="#contact" class="btn-primary inline-flex items-center justify-center px-8 py-4 rounded-2xl">
+                    Get a Free Quote
+                  </a>
+                  <a href="tel:2156038009"
+                    class="btn-secondary inline-flex items-center justify-center px-8 py-4 rounded-2xl">
+                    Call (215) 603-8009
+                  </a>
+                </div>
+                <ul class="hero-badges">
+                  <li>Interior &amp; exterior specialists</li>
+                  <li>Cabinet refinishing &amp; custom trim</li>
+                  <li>Serving the Philadelphia area</li>
+                </ul>
+              </div>
+            </div>
+            <div class="hero-quick-links">
+              <a href="#services" class="hero-quick-link">
+                <span class="hero-quick-icon">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                      d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" />
+                  </svg>
+                </span>
+                <div>
+                  <span class="hero-quick-title">Explore Services</span>
+                  <span class="hero-quick-text">Interior, exterior &amp; specialty work</span>
+                </div>
+              </a>
+              <a href="gallery.html" class="hero-quick-link">
+                <span class="hero-quick-icon">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                      d="M4 7a2 2 0 012-2h3l1-2h4l1 2h3a2 2 0 012 2v9a2 2 0 01-2 2H6a2 2 0 01-2-2V7z" />
+                    <circle cx="12" cy="13.5" r="2.8" stroke-width="1.6" stroke="currentColor" fill="none" />
+                  </svg>
+                </span>
+                <div>
+                  <span class="hero-quick-title">View Gallery</span>
+                  <span class="hero-quick-text">See finishes &amp; transformations</span>
+                </div>
+              </a>
+              <a href="#contact" class="hero-quick-link">
+                <span class="hero-quick-icon">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                      d="M4 6h16a2 2 0 012 2v7a2 2 0 01-2 2h-6l-4 4v-4H4a2 2 0 01-2-2V8a2 2 0 012-2z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M8 11h8M8 14h5" />
+                  </svg>
+                </span>
+                <div>
+                  <span class="hero-quick-title">Schedule a Consultation</span>
+                  <span class="hero-quick-text">Connect with our renovation team</span>
+                </div>
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -361,6 +400,11 @@
                 <p>
                   Perfection drives us. Let’s make your home <span class="gradient-text">extraordinary</span>.
                 </p>
+                <ul class="about-highlights">
+                  <li>Detailed prep work &amp; immaculate cleanup on every project</li>
+                  <li>Collaborative partnerships with homeowners, designers &amp; contractors</li>
+                  <li>Trusted service throughout Philadelphia and the surrounding tri-state area</li>
+                </ul>
               </div>
             </div>
           </div>
@@ -383,164 +427,80 @@
             <h2 class="text-4xl lg:text-5xl font-bold text-white">
               <span class="gradient-text">Services</span>
             </h2>
+            <p class="section-intro max-w-2xl mx-auto">
+              Comprehensive painting, refinishing, and renovation expertise tailored to elevate every surface of your
+              home or business.
+            </p>
           </div>
-
-          <!-- Mobile: Simple Links -->
-          <div class="md:hidden space-y-3 mb-6">
-          <a href="interior-painting.html" class="mobile-service-link flex items-center p-4 rounded-xl">
-            <div
-              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
-              <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"></path>
-              </svg>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold text-white">Interior Painting</h3>
-              <p class="text-sm text-gray-400">Walls, ceilings & trim</p>
-            </div>
-            <svg class="w-5 h-5 text-gray-400 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-            </svg>
-          </a>
-
-          <a href="exterior-painting.html" class="mobile-service-link flex items-center p-4 rounded-xl">
-            <div
-              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
-              <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M8.25 9V7a3.75 3.75 0 117.5 0v2m-7.5 4v6.75A1.25 1.25 0 009.5 21h5a1.25 1.25 0 001.25-1.25V13M8.25 9h7.5a1.25 1.25 0 011.25 1.25V13">
-                </path>
-              </svg>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold text-white">Exterior Painting</h3>
-              <p class="text-sm text-gray-400">Siding, decks & more</p>
-            </div>
-            <svg class="w-5 h-5 text-gray-400 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-            </svg>
-          </a>
-
-          <a href="#" class="mobile-service-link flex items-center p-4 rounded-xl">
-            <div
-              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
-              <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z">
-                </path>
-              </svg>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold text-white">Trim Work</h3>
-              <p class="text-sm text-gray-400">Custom woodwork & repairs</p>
-            </div>
-            <svg class="w-5 h-5 text-gray-400 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-            </svg>
-          </a>
-
-          <a href="#" class="mobile-service-link flex items-center p-4 rounded-xl">
-            <div
-              class="w-12 h-12 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-lg flex items-center justify-center mr-4">
-              <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M3 4h18M3 8h18M3 12h18M3 16h18M3 20h18"></path>
-              </svg>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold text-white">Remodeling</h3>
-              <p class="text-sm text-gray-400">Kitchens, baths & more</p>
-            </div>
-            <svg class="w-5 h-5 text-gray-400 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-            </svg>
-          </a>
-          </div>
-
-          <!-- Desktop: Compact horizontal row -->
-          <div class="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-4 xl:gap-6">
-          <a href="interior-painting.html" class="desktop-service-link group block h-full">
-            <div
-              class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow h-full">
-              <div
-                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
-                <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"></path>
+          <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 xl:gap-6">
+            <a href="interior-painting.html" class="service-card group">
+              <span class="service-card-icon">
+                <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                    d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" />
                 </svg>
+              </span>
+              <div class="flex flex-col gap-3">
+                <h3 class="service-card-title">Interior Painting</h3>
+                <p class="service-card-description">Walls, ceilings &amp; trim finished with precision</p>
+                <span class="service-card-link">Learn more
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
+                  </svg>
+                </span>
               </div>
-              <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
-                Interior Painting
-              </h3>
-              <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
-                Full service for your entire home
-              </p>
-            </div>
-          </a>
-
-          <a href="exterior-painting.html" class="desktop-service-link group block h-full">
-            <div
-              class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow h-full">
-              <div
-                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
-                <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M8.25 9V7a3.75 3.75 0 117.5 0v2m-7.5 4v6.75A1.25 1.25 0 009.5 21h5a1.25 1.25 0 001.25-1.25V13M8.25 9h7.5a1.25 1.25 0 011.25 1.25V13">
-                  </path>
+            </a>
+            <a href="exterior-painting.html" class="service-card group">
+              <span class="service-card-icon">
+                <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                    d="M8.25 9V7a3.75 3.75 0 117.5 0v2m-7.5 4v6.75A1.25 1.25 0 009.5 21h5a1.25 1.25 0 001.25-1.25V13M8.25 9h7.5a1.25 1.25 0 011.25 1.25V13" />
                 </svg>
+              </span>
+              <div class="flex flex-col gap-3">
+                <h3 class="service-card-title">Exterior Painting</h3>
+                <p class="service-card-description">Protective coatings for siding, decks &amp; masonry</p>
+                <span class="service-card-link">Learn more
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
+                  </svg>
+                </span>
               </div>
-              <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
-                Exterior Painting
-              </h3>
-              <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
-                Siding, decks & more
-              </p>
-            </div>
-          </a>
-
-          <a href="carpentry.html" class="desktop-service-link group block h-full">
-            <div
-              class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow h-full">
-              <div
-                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
-                <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z">
-                  </path>
+            </a>
+            <a href="carpentry.html" class="service-card group">
+              <span class="service-card-icon">
+                <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                    d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
                 </svg>
+              </span>
+              <div class="flex flex-col gap-3">
+                <h3 class="service-card-title">Custom Installs</h3>
+                <p class="service-card-description">Built-ins, trim upgrades &amp; tailored carpentry</p>
+                <span class="service-card-link">Learn more
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
+                  </svg>
+                </span>
               </div>
-              <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
-                Custom Installs
-              </h3>
-              <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
-                Custom installs & repairs
-              </p>
-            </div>
-          </a>
-
-          <a href="remodeling.html" class="desktop-service-link group block h-full">
-            <div
-              class="flex flex-col items-center text-center p-6 rounded-xl glass-card transition-all duration-300 hover:scale-105 hover:shadow-glow h-full">
-              <div
-                class="w-16 h-16 bg-gradient-to-br from-yellow-500 to-yellow-600 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
-                <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M3 4h18M3 8h18M3 12h18M3 16h18M3 20h18"></path>
+            </a>
+            <a href="remodeling.html" class="service-card group">
+              <span class="service-card-icon">
+                <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"
+                    d="M3 4h18M3 8h18M3 12h18M3 16h18M3 20h18" />
                 </svg>
+              </span>
+              <div class="flex flex-col gap-3">
+                <h3 class="service-card-title">Refinishing &amp; Remodeling</h3>
+                <p class="service-card-description">Cabinetry, kitchens, baths &amp; full-room refreshes</p>
+                <span class="service-card-link">Learn more
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
+                  </svg>
+                </span>
               </div>
-              <h3
-                class="text-xl font-semibold text-white mb-2 group-hover:text-yellow-300 transition-colors duration-300">
-                Refinishing
-              </h3>
-              <p class="text-sm text-gray-400 group-hover:text-gray-300 transition-colors duration-300">
-                Kitchen cabinets, built-ins & more
-              </p>
-            </div>
-          </a>
+            </a>
           </div>
         </div>
       </div>

--- a/interior-painting.html
+++ b/interior-painting.html
@@ -97,8 +97,7 @@
                 role="menu"></div>
             </div>
             <a href="index.html#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <div class="hidden md:flex items-center space-x-3 ml-4">
@@ -139,7 +138,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -148,7 +147,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -169,7 +168,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
             <a href="interior-painting.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
               Painting</a>
@@ -193,11 +192,11 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+          <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
+      </div>
+        <div class="px-4 pt-3 pb-5">
+          <a href="index.html#contact" class="mobile-cta">Get a Quote</a>
         </div>
-        <a href="index.html#contact"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
-          Us</a>
       </div>
   </header>
 

--- a/remodeling.html
+++ b/remodeling.html
@@ -96,8 +96,7 @@
                 role="menu"></div>
             </div>
             <a href="index.html#contact"
-              class="glass-nav-item hover-glass-nav px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200">Contact
-              Us</a>
+              class="nav-cta px-5 py-2 rounded-xl text-sm font-semibold transition-transform duration-200">Get a Quote</a>
           </nav>
 
           <div class="hidden md:flex items-center space-x-3 ml-4">
@@ -138,7 +137,7 @@
         <!-- Contact Info Section for Mobile -->
         <div class="border-b border-gray-700/30 py-4 px-4 space-y-2">
           <a href="tel:2156038009"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.308 1.154a11.06 11.06 0 006.086 6.086l1.154-2.308a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z">
@@ -147,7 +146,7 @@
             (215) 603-8009
           </a>
           <a href="mailto:peterkpaint@gmail.com"
-            class="flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors duration-200">
+            class="flex items-center text-sm text-amber-200 hover:text-amber-100 transition-colors duration-200 font-medium">
             <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
@@ -168,7 +167,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-services-menu" class="hidden pl-4 bg-gray-750/50">
+          <div id="mobile-services-menu" class="hidden pl-4 space-y-1">
             <a href="interior-painting.html"
               class="block py-3 px-4 text-sm text-gray-200 hover:bg-white/10 transition-colors duration-200">Interior
               Painting</a>
@@ -191,11 +190,11 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
             </svg>
           </button>
-          <div id="mobile-gallery-menu" class="hidden pl-4 bg-gray-750/50"></div>
+          <div id="mobile-gallery-menu" class="hidden pl-4 space-y-1"></div>
+      </div>
+        <div class="px-4 pt-3 pb-5">
+          <a href="index.html#contact" class="mobile-cta">Get a Quote</a>
         </div>
-        <a href="index.html#contact"
-          class="block py-3 px-4 text-base text-gray-200 hover:bg-white/10 transition-colors duration-200">Contact
-          Us</a>
       </div>
   </header>
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,9 +1,110 @@
 /* ==================== BASE STYLES ==================== */
 
 /* Base body styles */
+:root {
+  --brand-bg: #050b1b;
+  --brand-bg-secondary: #0f172a;
+  --brand-card: rgba(15, 23, 42, 0.72);
+  --brand-card-strong: rgba(15, 23, 42, 0.88);
+  --brand-border: rgba(148, 163, 184, 0.18);
+  --brand-border-strong: rgba(148, 163, 184, 0.28);
+  --brand-accent: #facc15;
+  --brand-accent-strong: #f59e0b;
+  --brand-accent-soft: rgba(250, 204, 21, 0.18);
+  --brand-text: #f8fafc;
+  --brand-muted: rgba(203, 213, 225, 0.78);
+}
+
 body {
   font-family: 'Inter', sans-serif; /* Ensure Inter font is primary */
   scroll-behavior: smooth; /* Smooth scrolling for anchor links */
+  background-color: var(--brand-bg);
+  background-image: radial-gradient(
+      circle at 12% 18%,
+      rgba(148, 163, 184, 0.16),
+      transparent 58%
+    ),
+    radial-gradient(
+      circle at 84% 8%,
+      rgba(250, 204, 21, 0.12),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 50% 105%,
+      rgba(56, 189, 248, 0.12),
+      transparent 65%
+    );
+  color: var(--brand-text);
+  min-height: 100vh;
+}
+
+.bg-shapes {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  mix-blend-mode: screen;
+}
+
+.bg-shape {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(120px);
+  opacity: 0.32;
+  transform: translate3d(0, 0, 0);
+  animation: shapeFloat 18s ease-in-out infinite alternate;
+}
+
+.bg-shape-1 {
+  width: 42vw;
+  height: 42vw;
+  top: -12vw;
+  left: -14vw;
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(56, 189, 248, 0.4),
+    rgba(15, 23, 42, 0)
+  );
+}
+
+.bg-shape-2 {
+  width: 38vw;
+  height: 38vw;
+  bottom: -16vw;
+  left: 18vw;
+  background: radial-gradient(
+    circle at 70% 70%,
+    var(--brand-accent-soft),
+    rgba(15, 23, 42, 0)
+  );
+}
+
+.bg-shape-3 {
+  width: 46vw;
+  height: 46vw;
+  top: 18%;
+  right: -18vw;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(99, 102, 241, 0.24),
+    rgba(15, 23, 42, 0)
+  );
+}
+
+@keyframes shapeFloat {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(0, -20px, 0) scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bg-shape {
+    animation: none;
+  }
 }
 
 /* Custom scrollbar for Webkit browsers (Chrome, Safari, Edge) */
@@ -28,28 +129,53 @@ body {
 
 /* ==================== HEADER & NAVIGATION ==================== */
 
-/* Improved header with better contrast */
+/* Elevated glass header with gentle contrast */
 .glass-header {
-  background: rgba(
-    0,
-    0,
-    0,
-    0.8
-  ) !important; /* Darker background for better contrast */
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  background: linear-gradient(
+      120deg,
+      rgba(7, 11, 23, 0.95),
+      rgba(7, 18, 34, 0.82)
+    )
+    !important;
+  border-bottom: 1px solid var(--brand-border);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+  box-shadow: 0 18px 45px rgba(6, 11, 25, 0.45);
 }
 
-/* Make navigation text more legible */
 .glass-nav-item {
-  background: rgba(255, 255, 255, 0.1) !important;
-  color: rgba(255, 255, 255, 0.95) !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5); /* Add text shadow for better readability */
+  background: rgba(148, 163, 184, 0.12) !important;
+  border: 1px solid transparent;
+  color: var(--brand-text) !important;
+  font-weight: 500;
+  text-shadow: none;
 }
 
-.hover-glass-nav:hover {
-  background: rgba(255, 255, 255, 0.2) !important;
-  color: white !important;
+.hover-glass-nav:hover,
+.glass-nav-item:focus-visible {
+  background: rgba(148, 163, 184, 0.22) !important;
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #ffffff !important;
+  box-shadow: 0 16px 35px rgba(8, 47, 73, 0.35);
+}
+
+.nav-cta {
+  background: linear-gradient(
+      135deg,
+      var(--brand-accent),
+      var(--brand-accent-strong)
+    )
+    !important;
+  color: #0f172a !important;
+  font-weight: 600;
+  border: none;
+  box-shadow: 0 18px 35px rgba(250, 204, 21, 0.28);
+}
+
+.nav-cta:hover,
+.nav-cta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px rgba(250, 204, 21, 0.36);
 }
 
 /* Desktop dropdown menu visibility on hover */
@@ -70,24 +196,68 @@ body {
 
 /* Improve dropdown menu legibility */
 .glass-dropdown {
-  background: rgba(0, 0, 0, 0.9) !important;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: linear-gradient(
+      145deg,
+      rgba(15, 23, 42, 0.92),
+      rgba(15, 23, 42, 0.75)
+    )
+    !important;
+  border: 1px solid var(--brand-border);
+  box-shadow: 0 28px 60px rgba(6, 11, 25, 0.55);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
 }
 
 /* Mobile menu improvements */
 #mobile-menu {
-  background: rgba(0, 0, 0, 0.9) !important;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: linear-gradient(
+      150deg,
+      rgba(15, 23, 42, 0.94),
+      rgba(15, 23, 42, 0.8)
+    )
+    !important;
+  border: 1px solid var(--brand-border);
+  border-top: none;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: 0 25px 55px rgba(6, 11, 25, 0.5);
 }
 
-#mobile-menu a {
-  text-shadow: 2px 2px 0px rgba(0, 0, 0, 0.9), -1px -1px 0px rgba(0, 0, 0, 0.9),
-    1px -1px 0px rgba(0, 0, 0, 0.9), -1px 1px 0px rgba(0, 0, 0, 0.9),
-    3px 3px 6px rgba(0, 0, 0, 0.8) !important;
-  color: rgba(255, 255, 255, 0.95) !important;
+#mobile-menu a,
+#mobile-menu button {
+  color: rgba(226, 232, 240, 0.92) !important;
   font-weight: 500 !important;
+  text-shadow: none !important;
+  border-radius: 0.75rem;
+}
+
+#mobile-menu a:hover,
+#mobile-menu button:hover {
+  background: rgba(148, 163, 184, 0.12) !important;
+  color: #ffffff !important;
+}
+
+.mobile-cta {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 0.85rem 1.25rem;
+  border-radius: 1rem;
+  font-weight: 600;
+  background: linear-gradient(
+      135deg,
+      var(--brand-accent),
+      var(--brand-accent-strong)
+    );
+  color: #0f172a !important;
+  box-shadow: 0 18px 38px rgba(250, 204, 21, 0.28);
+}
+
+.mobile-cta:hover,
+.mobile-cta:focus-visible {
+  box-shadow: 0 24px 48px rgba(250, 204, 21, 0.34);
+  transform: translateY(-1px);
 }
 
 nav a.active,
@@ -154,64 +324,200 @@ nav button.active,
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.6));
+  background: linear-gradient(
+    160deg,
+    rgba(6, 13, 29, 0.85) 0%,
+    rgba(7, 16, 34, 0.58) 45%,
+    rgba(6, 13, 29, 0.88) 100%
+  );
   z-index: -1; /* Above slides, below content */
 }
 
-/* Improve hero text legibility */
-.hero-glass-overlay {
-  background: rgba(
-    0,
-    0,
-    0,
-    0.2
-  ) !important; /* Darker overlay for better text contrast */
-  backdrop-filter: blur(1px);
+.glass-card-hero {
+  background: linear-gradient(
+      155deg,
+      rgba(15, 23, 42, 0.92),
+      rgba(15, 23, 42, 0.6)
+    )
+    !important;
+  border: 1px solid var(--brand-border) !important;
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+  box-shadow: 0 38px 90px rgba(5, 11, 23, 0.55) !important;
+  padding: clamp(2.5rem, 5vw, 3.5rem) !important;
 }
 
-/* Add text shadows to hero text for better readability */
 .glass-card-hero h1,
 .glass-card-hero p {
-  text-shadow: 2px 2px 0px black, -2px -2px 0px black, 2px -2px 0px black,
-    -2px 2px 0px black, 1px 1px 0px black, -1px -1px 0px black,
-    1px -1px 0px black, -1px 1px 0px black, 4px 4px 8px black,
-    0 0 10px rgba(255, 255, 255, 0.5) !important;
-  color: white !important;
-  font-weight: 700 !important;
+  color: var(--brand-text) !important;
+  text-shadow: 0 18px 35px rgba(2, 6, 23, 0.5);
 }
 
-/* Specifically target the main hero heading */
 .glass-card-hero h1 {
-  text-shadow: 2px 2px 0px black, -2px -2px 0px black, 2px -2px 0px black,
-    -2px 2px 0px black, 1px 1px 0px black, -1px -1px 0px black,
-    1px -1px 0px black, -1px 1px 0px black, 4px 4px 8px black,
-    0 0 10px rgba(255, 255, 255, 0.5) !important;
-  color: white !important;
-  font-weight: 700 !important;
+  letter-spacing: -0.02em;
 }
 
-.glass-card-hero h1 .gradient-text {
-  text-shadow: 3px 3px 0px rgba(0, 0, 0, 0.3),
-    -1px -1px 0px rgba(200, 161, 72, 0.9), 1px -1px 0px rgba(79, 50, 8, 0.9),
-    -1px 1px 0px rgba(0, 0, 0, 0.9), 4px 4px 8px rgba(0, 0, 0, 0.8),
-    0 0 20px rgba(212, 175, 55, 0.6) !important;
-}
-.glass-card-hero p .gradient-text {
-  /* Add custom text-shadow properties here if desired */
-  /* For example, to give it a subtle glow similar to the h1, but perhaps less intense: */
-  text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.195),
-    -1px -1px 0px rgba(200, 161, 72, 0.7), 1px -1px 0px rgba(79, 50, 8, 0.7),
-    -1px 1px 0px rgba(0, 0, 0, 0.7), 2px 2px 4px rgba(0, 0, 0, 0.6),
-    0 0 10px rgba(212, 175, 55, 0.4) !important;
+.glass-card-hero p {
+  color: rgba(226, 232, 240, 0.92) !important;
 }
 
-/* Make the hero card background more refined */
-.glass-card-hero {
-  background: none !important; /* Remove the big dark block */
-  backdrop-filter: none !important;
-  border: none !important;
-  box-shadow: none !important;
-  padding: 2rem !important; /* Reduce padding so it's not so massive */
+.hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.hero-subtitle {
+  font-size: clamp(1rem, 2.6vw, 1.3rem);
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .hero-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 768px) {
+  .hero-actions {
+    justify-content: flex-start;
+  }
+}
+
+.btn-primary {
+  background: linear-gradient(
+      135deg,
+      var(--brand-accent),
+      var(--brand-accent-strong)
+    )
+    !important;
+  box-shadow: 0 20px 45px rgba(250, 204, 21, 0.35);
+  text-shadow: none;
+  border: none;
+  color: #0f172a !important;
+  font-weight: 600;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  box-shadow: 0 28px 55px rgba(250, 204, 21, 0.4);
+  transform: translateY(-2px);
+}
+
+.btn-secondary {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--brand-text) !important;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  font-weight: 600;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  background: rgba(148, 163, 184, 0.22);
+  border-color: rgba(148, 163, 184, 0.45);
+  transform: translateY(-2px);
+}
+
+.hero-badges {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.hero-badges li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  color: rgba(226, 232, 240, 0.88);
+  font-size: 0.85rem;
+}
+
+.hero-badges li::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: linear-gradient(
+    120deg,
+    var(--brand-accent),
+    var(--brand-accent-strong)
+  );
+}
+
+.hero-quick-links {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .hero-quick-links {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.hero-quick-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1.5rem;
+  text-decoration: none;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid var(--brand-border);
+  box-shadow: 0 20px 45px rgba(5, 11, 23, 0.45);
+  transition: transform 0.35s ease, box-shadow 0.35s ease,
+    border-color 0.35s ease;
+}
+
+.hero-quick-link:hover,
+.hero-quick-link:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 28px 55px rgba(5, 11, 23, 0.55),
+    0 0 35px rgba(250, 204, 21, 0.22);
+}
+
+.hero-quick-icon {
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(250, 204, 21, 0.14);
+  border: 1px solid rgba(250, 204, 21, 0.32);
+  color: var(--brand-accent);
+}
+
+.hero-quick-title {
+  display: block;
+  font-weight: 600;
+  color: var(--brand-text);
+}
+
+.hero-quick-text {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
 }
 
 /* Add your slide images here - easily customizable */
@@ -376,11 +682,16 @@ nav button.active,
 
 /* Floating info cards - make text more legible */
 .glass-card {
-  background: rgba(255, 255, 255, 0.05) !important;
-  backdrop-filter: blur(15px);
-  -webkit-backdrop-filter: blur(15px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(
+      150deg,
+      rgba(15, 23, 42, 0.78),
+      rgba(15, 23, 42, 0.56)
+    )
+    !important;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--brand-border);
+  box-shadow: 0 22px 55px rgba(5, 11, 23, 0.4);
 }
 
 .glass-card .gradient-text {
@@ -388,44 +699,148 @@ nav button.active,
 }
 
 .glass-card-strong {
-  background: rgba(255, 255, 255, 0.08) !important;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  background: linear-gradient(
+      160deg,
+      rgba(15, 23, 42, 0.88),
+      rgba(15, 23, 42, 0.64)
+    )
+    !important;
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--brand-border-strong);
+  box-shadow: 0 28px 70px rgba(5, 11, 23, 0.5);
 }
 
 /* ==================== SERVICES SECTION ==================== */
 
-/* Service Cards - Enhanced glass effect */
 .service-card {
-  background: rgba(255, 255, 255, 0.06) !important;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.12) !important;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3) !important;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  background: linear-gradient(
+      155deg,
+      rgba(15, 23, 42, 0.82),
+      rgba(15, 23, 42, 0.68)
+    )
+    !important;
+  border: 1px solid var(--brand-border) !important;
+  border-radius: 1.25rem;
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 22px 55px rgba(5, 11, 23, 0.45) !important;
+  transition: transform 0.35s ease, box-shadow 0.35s ease,
+    border-color 0.35s ease, background 0.35s ease;
 }
 
 .service-card:hover {
-  background: rgba(255, 255, 255, 0.1) !important;
-  border-color: rgba(212, 175, 55, 0.3) !important;
-  transform: translateY(-8px) scale(1.02);
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4), 0 0 40px rgba(212, 175, 55, 0.2) !important;
+  transform: translateY(-6px);
+  border-color: rgba(250, 204, 21, 0.45) !important;
+  box-shadow: 0 32px 65px rgba(5, 11, 23, 0.55),
+    0 0 35px rgba(250, 204, 21, 0.2) !important;
+  background: linear-gradient(
+      155deg,
+      rgba(15, 23, 42, 0.9),
+      rgba(15, 23, 42, 0.72)
+    )
+    !important;
 }
 
-/* Make service icons more premium */
-.service-card .bg-gradient-to-br {
-  background: linear-gradient(135deg, #c8a148, #4f3208) !important;
-  box-shadow: 0 8px 25px rgba(212, 175, 55, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2) !important;
-  transition: all 0.3s ease;
+.service-card-icon {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(250, 204, 21, 0.14);
+  border: 1px solid rgba(250, 204, 21, 0.32);
+  color: var(--brand-accent);
+  transition: transform 0.35s ease;
 }
 
-.service-card:hover .bg-gradient-to-br {
-  transform: scale(1.1) rotate(5deg);
-  box-shadow: 0 12px 35px rgba(212, 175, 55, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.3) !important;
+.service-card:hover .service-card-icon {
+  transform: scale(1.05) translateY(-2px);
+}
+
+.service-card-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--brand-text);
+}
+
+.service-card-description {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.6;
+}
+
+.service-card-link {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: rgba(250, 204, 21, 0.85);
+  transition: gap 0.3s ease, color 0.3s ease;
+}
+
+.service-card-link svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  transition: transform 0.3s ease;
+}
+
+.service-card:hover .service-card-link {
+  color: var(--brand-accent);
+  gap: 0.45rem;
+}
+
+.service-card:hover .service-card-link svg {
+  transform: translateX(4px);
+}
+
+.section-intro {
+  margin-top: 0.75rem;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.7;
+}
+
+.about-highlights {
+  margin-top: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .about-highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.about-highlights li {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--brand-border);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.about-highlights li::before {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    var(--brand-accent),
+    var(--brand-accent-strong)
+  );
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.4);
 }
 
 /* ==================== GALLERY SECTION ==================== */
@@ -498,41 +913,56 @@ nav button.active,
 
 /* Contact Section - Premium glass card */
 .contact-card {
-  background: rgba(255, 255, 255, 0.08) !important;
-  backdrop-filter: blur(25px);
-  -webkit-backdrop-filter: blur(25px);
-  border: 1px solid rgba(255, 255, 255, 0.15) !important;
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4) !important;
+  background: linear-gradient(
+      150deg,
+      rgba(15, 23, 42, 0.9),
+      rgba(15, 23, 42, 0.65)
+    )
+    !important;
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border: 1px solid var(--brand-border-strong) !important;
+  box-shadow: 0 32px 80px rgba(5, 11, 23, 0.55) !important;
 }
 
 /* Contact icons - glass treatment */
 .contact-card .glass-card {
-  background: rgba(255, 255, 255, 0.06) !important;
-  border: 1px solid rgba(212, 175, 55, 0.2) !important;
+  background: rgba(148, 163, 184, 0.12) !important;
+  border: 1px solid rgba(250, 204, 21, 0.28) !important;
   transition: all 0.3s ease;
 }
 
 .contact-card .glass-card:hover {
-  background: rgba(212, 175, 55, 0.1) !important;
-  border-color: rgba(212, 175, 55, 0.4) !important;
-  transform: scale(1.05);
+  background: rgba(250, 204, 21, 0.16) !important;
+  border-color: rgba(250, 204, 21, 0.45) !important;
+  transform: translateY(-2px);
 }
 
 /* ==================== FOOTER ==================== */
 
 /* Footer - Glass treatment */
 footer {
-  background: rgba(255, 255, 255, 0.03) !important;
-  backdrop-filter: blur(15px);
-  -webkit-backdrop-filter: blur(15px);
-  border-top: 1px solid rgba(255, 255, 255, 0.08) !important;
+  background: linear-gradient(
+      180deg,
+      rgba(15, 23, 42, 0.85),
+      rgba(15, 23, 42, 0.6)
+    )
+    !important;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-top: 1px solid var(--brand-border);
 }
 
 /* ==================== VISUAL ENHANCEMENTS ==================== */
 
 /* Gradient text effect */
 .gradient-text {
-  background: linear-gradient(135deg, #c8a148, #4f3208);
+  background: linear-gradient(
+    135deg,
+    var(--brand-accent),
+    #f97316 55%,
+    var(--brand-accent-strong)
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -540,12 +970,17 @@ footer {
 
 /* Gradient button matching logo colors */
 .btn-gold {
-  background: linear-gradient(135deg, #c8a148, #4f3208);
-  color: #fff;
+  background: linear-gradient(
+    135deg,
+    var(--brand-accent),
+    var(--brand-accent-strong)
+  );
+  color: #0f172a;
 }
 
 .btn-gold:hover {
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4), 0 0 40px rgba(212, 175, 55, 0.2);
+  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4),
+    0 0 40px rgba(250, 204, 21, 0.22);
 }
 
 /* Floating animation for CTA button */
@@ -566,7 +1001,7 @@ footer {
 /* Enhanced contact section */
 .contact-card {
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--brand-border);
 }
 
 /* Enhanced transitions for better UX */
@@ -578,7 +1013,7 @@ button {
 /* Focus states for accessibility */
 a:focus,
 button:focus {
-  outline: 2px solid #c8a148;
+  outline: 2px solid var(--brand-accent);
   outline-offset: 2px;
 }
 
@@ -597,24 +1032,28 @@ button:focus {
 
 /* Enhanced shadow system */
 .shadow-glow {
-  box-shadow: 0 0 20px rgba(212, 175, 55, 0.3);
+  box-shadow: 0 0 20px rgba(250, 204, 21, 0.28);
 }
 
 .shadow-glow-hover:hover {
-  box-shadow: 0 0 30px rgba(212, 175, 55, 0.4);
+  box-shadow: 0 0 30px rgba(250, 204, 21, 0.32);
 }
 
 /* Improve button visibility */
 .btn-primary {
-  background: linear-gradient(135deg, #c8a148, #4f3208) !important;
-  box-shadow: 0 4px 15px rgba(212, 175, 55, 0.4);
-  text-shadow: none; /* Buttons don't need text shadow */
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: linear-gradient(
+      135deg,
+      var(--brand-accent),
+      var(--brand-accent-strong)
+    )
+    !important;
+  box-shadow: 0 20px 45px rgba(250, 204, 21, 0.32);
+  border: none;
+  color: #0f172a !important;
 }
 
 .btn-primary:hover {
-  box-shadow: 0 6px 20px rgba(212, 175, 55, 0.6);
-  transform: translateY(-2px);
+  box-shadow: 0 26px 55px rgba(250, 204, 21, 0.4);
 }
 
 /* ==================== VISUAL CONSISTENCY UPGRADES ==================== */


### PR DESCRIPTION
## Summary
- refresh the homepage hero with a glassmorphism overlay, dual call-to-action buttons, and quick navigation cards for services, gallery, and contact
- restructure the services section into a single responsive grid and add highlight callouts in the About block for easier scannability
- update global styling, navigation CTAs, and mobile menus across marketing pages to use the new gold accent palette and improved backgrounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca396ec4b0832b975a190051c1e4ca