### PR TITLE
Fix gallery builder conflicts and stabilize gallery UI

### DIFF
--- a/src/gallery.js
+++ b/src/gallery.js
@@ -1,7 +1,5 @@
-const PLACEHOLDER_IMAGE =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-
 let lightboxInitialized = false;
+let gridListenerBound = false;
 let reducedMotionStylesApplied = false;
 let reducedMotionListenerRegistered = false;
 
@@ -215,14 +213,18 @@ const initGalleryUI = (gridElement) => {
   const prevImage = () => updateImageFromIndex(currentImageIndex - 1);
 
   const galleryItems = getGalleryItems();
-  galleryItems.forEach((item) => {
-    item.addEventListener('click', () => {
-      const items = getGalleryItems();
-      const index = items.indexOf(item);
-      if (index !== -1) {
-        openLightbox(index);
-      }
+
+  if (!gridListenerBound) {
+    galleryItems.forEach((item) => {
+      item.addEventListener('click', () => {
+        const items = getGalleryItems();
+        const index = items.indexOf(item);
+        if (index !== -1) {
+          openLightbox(index);
+        }
+      });
     });
+
     gridListenerBound = true;
   }
 
@@ -250,6 +252,7 @@ const initGalleryUI = (gridElement) => {
     });
 
     let touchStartX = 0;
+    let touchEndX = 0;
 
     lightbox.addEventListener('touchstart', (event) => {
       if (event.changedTouches.length > 0) {


### PR DESCRIPTION
## Summary
- rebuild `buildGallery` to resolve merge remnants, normalize category data, and deduplicate image URLs
- harden gallery lightbox initialization by only binding listeners once and defining missing touch state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb4bcbae4832bb4783b6a0b772c5c