### PR TITLE
Restore gallery build and UI logic after merge regression

### DIFF
--- a/src/gallery-builder.js
+++ b/src/gallery-builder.js
@@ -6,10 +6,37 @@ const COVER_IMAGE_REGEX = /(^|\/)cover\.(jpg|jpeg|png|webp)(\?|$)/i;
 const ROOT_IMAGE_PREFIX = 'painting_';
 const EXCLUDED_CATEGORY = 'Commercial';
 
-const renameCategory = (name) =>
-  name === 'Carpentry' ? 'Custom Installs' : name;
+const createEmptyResult = () => ({
+  categories: [],
+  imagesByCategory: {},
+  coverByCategory: {},
+});
 
-const slugify = (name) => name.toLowerCase().replace(/\s+/g, '-');
+const normalizeCategoryName = (name) => {
+  if (typeof name !== 'string') return '';
+
+  const trimmed = name.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed === EXCLUDED_CATEGORY ||
+    trimmed.startsWith(ROOT_IMAGE_PREFIX)
+  ) {
+    return '';
+  }
+
+  return trimmed === 'Carpentry' ? 'Custom Installs' : trimmed;
+};
+
+const slugifyCategory = (name) =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const isCoverImage = (fileName = '') => COVER_IMAGE_REGEX.test(fileName);
+
+const normalizeImageUrl = (url) =>
+  typeof url === 'string' ? url.trim() : '';
 
 let imageModules = {};
 try {
@@ -22,86 +49,52 @@ try {
   imageModules = {};
 }
 
-<<<<<<< ours
-const createEmptyResult = () => ({
-  categories: [],
-  imagesByCategory: {},
-  coverByCategory: {},
-});
-
-=======
->>>>>>> theirs
-const normalizeCategoryName = (name) => {
-  if (typeof name !== 'string') return '';
-  const trimmed = name.trim();
-  return trimmed === 'Carpentry' ? 'Custom Installs' : trimmed;
-};
-
-const slugifyCategory = (name) =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-const isCoverImage = (fileName) =>
-  /(^|\/)cover\.(jpg|jpeg|png|webp)(\?|$)/i.test(fileName || '');
-
 export async function buildGallery() {
   const imagesByCategory = {};
   const coverByCategory = {};
   const categoriesBySlug = new Map();
 
   const ensureCategory = (categoryName) => {
-    if (!categoryName || categoryName === 'Commercial') {
-      return null;
-    }
-
     const displayName = normalizeCategoryName(categoryName);
-    if (!displayName) {
-      return null;
-    }
+    if (!displayName) return null;
 
     const slug = slugifyCategory(displayName);
-    if (!slug) {
-      return null;
-    }
+    if (!slug) return null;
 
     if (!imagesByCategory[slug]) {
       imagesByCategory[slug] = [];
     }
 
     categoriesBySlug.set(slug, displayName);
-    return { slug, displayName };
+    return { slug, name: displayName };
   };
 
-  const registerImage = (categoryName, url, fileName) => {
-    const category = ensureCategory(categoryName);
-    if (!category || typeof url !== 'string' || url.length === 0) {
-      return;
-    }
+  const registerImage = (categoryName, url, fileName = '') => {
+    const normalizedUrl = normalizeImageUrl(url);
+    if (!normalizedUrl) return;
 
-    imagesByCategory[category.slug].push(url);
+    const category = ensureCategory(categoryName);
+    if (!category) return;
+
+    imagesByCategory[category.slug].push(normalizedUrl);
+
     if (!coverByCategory[category.slug] && isCoverImage(fileName)) {
-      coverByCategory[category.slug] = url;
+      coverByCategory[category.slug] = normalizedUrl;
     }
   };
 
   if (Object.keys(imageModules).length > 0) {
     for (const [path, url] of Object.entries(imageModules)) {
       const parts = path.split('/');
-      const fileName = parts[parts.length - 1];
-<<<<<<< ours
+      const fileName = parts[parts.length - 1] || '';
 
-      if (fileName.startsWith(ROOT_IMAGE_PREFIX)) continue;
-=======
->>>>>>> theirs
-      if (!fileName || fileName.startsWith('painting_')) continue;
+      if (!fileName || fileName.startsWith(ROOT_IMAGE_PREFIX)) continue;
 
       const galleryIdx = parts.indexOf('gallery');
       if (galleryIdx === -1) continue;
 
       const categoryName = parts[galleryIdx + 1];
-      if (!categoryName || categoryName.startsWith('painting_')) continue;
+      if (!categoryName) continue;
 
       registerImage(categoryName, url, fileName);
     }
@@ -110,32 +103,17 @@ export async function buildGallery() {
       const res = await fetch('gallery.json');
       if (res.ok) {
         const data = await res.json();
-<<<<<<< ours
-        Object.entries(data).forEach(([categoryName, urls]) => {
-          if (!Array.isArray(urls)) return;
-          urls.forEach((url) => registerImage(categoryName, url));
-        });
-=======
->>>>>>> theirs
         if (data && typeof data === 'object') {
           for (const [categoryName, urls] of Object.entries(data)) {
-            const category = ensureCategory(categoryName);
-            if (!category) continue;
+            if (!Array.isArray(urls)) continue;
 
-            const validUrls = Array.isArray(urls)
-<<<<<<< ours
-              ? urls.filter(
-                  (value) => typeof value === 'string' && value.length > 0
-                )
-=======
-              ? urls.filter((value) => typeof value === 'string' && value.length > 0)
->>>>>>> theirs
-              : [];
-
-            for (const value of validUrls) {
-              const fileName = value.split('/').pop();
-              registerImage(categoryName, value, fileName);
-            }
+            urls
+              .map((value) => normalizeImageUrl(value))
+              .filter((value) => value.length > 0)
+              .forEach((value) => {
+                const fileName = value.split('/').pop() || '';
+                registerImage(categoryName, value, fileName);
+              });
           }
         }
       }
@@ -144,43 +122,23 @@ export async function buildGallery() {
     }
   }
 
-<<<<<<< ours
-  if (categories.size === 0) {
+  if (categoriesBySlug.size === 0) {
     return createEmptyResult();
   }
 
-  const imagesByCategory = {};
-  const sortedCategories = Array.from(categories.values()).sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
-=======
->>>>>>> theirs
-  // Sort and deduplicate image URLs within each category to ensure predictable ordering
-  for (const slug of Object.keys(imagesByCategory)) {
-    const uniqueUrls = Array.from(new Set(imagesByCategory[slug]));
+  for (const [slug, urls] of Object.entries(imagesByCategory)) {
+    const uniqueUrls = Array.from(new Set(urls));
     uniqueUrls.sort((a, b) => a.localeCompare(b));
     imagesByCategory[slug] = uniqueUrls;
   }
 
-<<<<<<< ours
-  sortedCategories.forEach(({ slug, images }) => {
-    images.sort((a, b) => a.localeCompare(b));
-    imagesByCategory[slug] = images;
-  });
-
-  const coverResult = {};
-  coverByCategory.forEach((url, slug) => {
-    coverResult[slug] = url;
-  });
-=======
->>>>>>> theirs
   const categories = Array.from(categoriesBySlug.entries())
     .map(([slug, name]) => ({ name, slug }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return {
-    categories: sortedCategories.map(({ name, slug }) => ({ name, slug })),
+    categories,
     imagesByCategory,
-    coverByCategory: coverResult,
+    coverByCategory,
   };
 }

--- a/src/gallery.js
+++ b/src/gallery.js
@@ -1,6 +1,3 @@
-const PLACEHOLDER_IMAGE =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-
 let lightboxInitialized = false;
 let reducedMotionStylesApplied = false;
 let reducedMotionListenerRegistered = false;
@@ -223,8 +220,7 @@ const initGalleryUI = (gridElement) => {
         openLightbox(index);
       }
     });
-    gridListenerBound = true;
-  }
+  });
 
   if (!lightboxInitialized) {
     lightboxClose.addEventListener('click', closeLightbox);
@@ -259,7 +255,7 @@ const initGalleryUI = (gridElement) => {
 
     lightbox.addEventListener('touchend', (event) => {
       if (event.changedTouches.length > 0) {
-        touchEndX = event.changedTouches[0].screenX;
+        const touchEndX = event.changedTouches[0].screenX;
         const swipeThreshold = 100;
         if (touchEndX < touchStartX - swipeThreshold) {
           nextImage();


### PR DESCRIPTION
## Summary
- rebuild the gallery data builder so it normalizes/slugifies categories, deduplicates URLs, and handles JSON fallback cleanly after the merge conflict
- repair the gallery UI script to remove broken merge artifacts, restore lightbox/touch handling, and keep the preload and reduced-motion helpers working

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb4bcbae4832bb4783b6a0b772c5c