### PR TITLE
Code review and performance improvements

### DIFF
--- a/src/gallery-builder.js
+++ b/src/gallery-builder.js
@@ -41,6 +41,14 @@ try {
   imageModules = {};
 }
 
+/**
+ * Builds gallery data by scanning image files or loading from gallery.json fallback.
+ * Uses Vite's import.meta.glob in development, falls back to JSON in production.
+ * @returns {Promise<Object>} Gallery data with categories, imagesByCategory, and coverByCategory
+ * @returns {Promise<Array>} returns.categories - Sorted array of {name, slug} category objects
+ * @returns {Promise<Object>} returns.imagesByCategory - Map of slug to image URL arrays
+ * @returns {Promise<Object>} returns.coverByCategory - Map of slug to cover image URLs
+ */
 export async function buildGallery() {
   const categories = new Map();
   const coverCandidates = {};

--- a/src/style.css
+++ b/src/style.css
@@ -1296,22 +1296,6 @@ button:focus {
   box-shadow: 0 0 30px rgba(250, 204, 21, 0.32);
 }
 
-/* Improve button visibility */
-.btn-primary {
-  background: linear-gradient(
-    135deg,
-    var(--brand-accent),
-    var(--brand-accent-strong)
-  ) !important;
-  box-shadow: 0 20px 45px rgba(250, 204, 21, 0.32);
-  border: none;
-  color: #0f172a !important;
-}
-
-.btn-primary:hover {
-  box-shadow: 0 26px 55px rgba(250, 204, 21, 0.4);
-}
-
 /* ==================== VISUAL CONSISTENCY UPGRADES ==================== */
 
 /* Make all section backgrounds consistent */


### PR DESCRIPTION
This commit implements a comprehensive set of improvements to enhance code quality, performance, security, and accessibility across the website. All changes are surgical and non-breaking to preserve existing functionality.

## Bug Fixes
- Fixed hero slideshow timer leak by clearing resumeTimeout before creating new one
- Added error handling for gallery category rendering to prevent crashes
- Fixed reduced motion listener registration logic for better reliability

## Performance Improvements
- Added throttling to parallax scroll handler (~60fps limit)
- Implemented shared IntersectionObserver instances to reduce memory usage
- Optimized observer reuse across gallery and nav-menu modules

## Security Enhancements
- Added HTML escaping for category names to prevent XSS attacks
- Added URL encoding for category slugs in links

## Code Quality
- Extracted magic numbers to named constants in all JS files
- Removed duplicate .btn-primary CSS rules
- Extracted duplicate dropdown logic into reusable initDesktopDropdown function
- Added comprehensive JSDoc comments to all main exported functions
- Improved code organization and readability

## Accessibility Improvements
- Added keyboard support (Enter/Space) for gallery items and slideshow indicators
- Enhanced lightbox with ARIA attributes (role, aria-modal, aria-label)
- Added aria-label for image position (e.g., "Image 3 of 10")
- Improved focus management by focusing close button when lightbox opens
- Made all interactive elements keyboard-accessible with tabindex

## Files Changed
- src/gallery.js: Error handling, constants, shared observer, keyboard support, ARIA labels
- src/hero-slideshow.js: Timer fix, throttling, constants, JSDoc, keyboard support
- src/nav-menu.js: XSS protection, dropdown refactor, shared observer, JSDoc
- src/gallery-builder.js: JSDoc documentation
- src/style.css: Removed duplicate .btn-primary rules

All changes tested to ensure no breaking functionality. Site remains fully operational.

## Summary
What changed and why?

## Acceptance Criteria
List the concrete, testable criteria.

## Checklist
- [ ] Tests: unit + one integration path
- [ ] Coverage ≥ 80% on new lines
- [ ] Lint/format/typecheck pass
- [ ] Performance within budget (P95 latency/memory)
- [ ] Security: input validation; no secrets in logs; deps audited
- [ ] Observability: at least one structured success/error log
- [ ] Docs updated (README/CHANGELOG/ADR)
- [ ] Feature flag + rollback noted (if risky)

## Logs/Screens
Paste relevant output.

## Risks & Rollback
Impact, blast radius, exact rollback steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broad cleanup focused on performance, accessibility, and security while preserving behavior.
> 
> - **Performance:** Replaces per-instance observers with shared `IntersectionObserver`s in `gallery.js` and `nav-menu.js`; throttles hero parallax; centralizes magic numbers into constants (swipe threshold, preload cap, observer config, intervals)
> - **Accessibility:** Adds keyboard activation (Enter/Space) for gallery items and slideshow indicators; enhances lightbox with ARIA (`role`, `aria-modal`, labels) and focus management; improves hover/motion handling via reduced-motion checks
> - **Stability:** Wraps gallery category rendering in try/catch with fallback messaging; fixes reduced-motion listener registration; ensures lightbox defaults and bounds checks
> - **Security:** Escapes gallery category names and URL-encodes slugs in nav menus to prevent XSS
> - **Code quality:** Extracts reusable `initDesktopDropdown` for desktop dropdown ARIA behavior; adds JSDoc to `buildGallery`; normalizes image lists/preloads with `MAX_PRELOAD_IMAGES`
> - **Styles:** Removes duplicate `.btn-primary` rules from `style.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d827f0f52524268e9848112ad67f2d3430d5da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->